### PR TITLE
BUG Switch the subsite on GET parameter only.

### DIFF
--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -11,14 +11,14 @@ class LeftAndMainSubsites extends Extension {
 		Requirements::javascript('subsites/javascript/LeftAndMain_Subsites.js');
 		Requirements::javascript('subsites/javascript/VirtualPage_Subsites.js');
 		
-		if(isset($_REQUEST['SubsiteID'])) {
+		if(isset($_GET['SubsiteID'])) {
 			// Clear current page when subsite changes (or is set for the first time)
-			if(!Session::get('SubsiteID') || $_REQUEST['SubsiteID'] != Session::get('SubsiteID')) {
+			if(!Session::get('SubsiteID') || $_GET['SubsiteID'] != Session::get('SubsiteID')) {
 				Session::clear("{$this->owner->class}.currentPage");
 			}
 			
 			// Update current subsite in session
-			Subsite::changeSubsite($_REQUEST['SubsiteID']);
+			Subsite::changeSubsite($_GET['SubsiteID']);
 			
 			//Redirect to clear the current page
 			$this->owner->redirect('admin/pages');

--- a/code/model/Subsite.php
+++ b/code/model/Subsite.php
@@ -273,13 +273,13 @@ JS;
 	 *
 	 * You can simulate subsite access without creating virtual hosts by appending ?SubsiteID=<ID> to the request.
 	 *
-	 * @todo Pass $request object from controller so we don't have to rely on $_REQUEST
+	 * @todo Pass $request object from controller so we don't have to rely on $_GET
 	 *
 	 * @param boolean $cache
 	 * @return int ID of the current subsite instance
 	 */
 	static function currentSubsiteID() {
-		if(isset($_REQUEST['SubsiteID'])) $id = (int)$_REQUEST['SubsiteID'];
+		if(isset($_GET['SubsiteID'])) $id = (int)$_GET['SubsiteID'];
 		else $id = Session::get('SubsiteID');
 
 		if($id === NULL) {


### PR DESCRIPTION
This fixes the bug where creating the top level pages is broken whenever
subsites module is installed. This is because the SubsiteID is
explicitly specified on AddForm POST submission, which incorrectly
triggers a redirect from LeftAndMainSubsites::init and the form action
never has a chance to execute.

Also do not look at POST when checking for the current subsite ID.
