### PR TITLE
Make LeftAndMain redirect direct to admin

### DIFF
--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -23,7 +23,7 @@ class LeftAndMainSubsites extends Extension {
 			Subsite::changeSubsite($_GET['SubsiteID']);
 			
 			//Redirect to clear the current page
-			return $this->owner->redirect('admin/pages');
+			return $this->owner->redirect('admin/');
 		}
 
 		// Set subsite ID based on currently shown record


### PR DESCRIPTION
Currently, using the Subsites dropdown in the admin interface causes the CMS to reload to admin/pages. This can cause issues if you have set another interface as your default (other than CMSMain).
