### PR TITLE
BUG: Fix filter issue in IE9

### DIFF
--- a/css/LeftAndMain_Subsites.css
+++ b/css/LeftAndMain_Subsites.css
@@ -35,6 +35,7 @@
 /* Custom chzn styles for dark blue background */
 .cms-subsites .chzn-container-single .chzn-single,
 .cms-subsites .chzn-container-active .chzn-single {
+	filter: none; /* Fix for IE9 */
 	border: 1px solid #152338;
 	background:#213557;
 	-webkit-box-shadow: inset 1px 0 0 rgba(255,255,255,.125), inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);


### PR DESCRIPTION
IE9's filter is overriding the dark background on the subsite's dropdown.
