### PR TITLE
Change the preview iframe to use injected SubsiteID GET/POST params.

### DIFF
--- a/code/extensions/SiteTreeSubsites.php
+++ b/code/extensions/SiteTreeSubsites.php
@@ -211,7 +211,7 @@ class SiteTreeSubsites extends DataExtension {
 		// Need to set the SubsiteID to null incase we've been in the CMS
 		Session::set('SubsiteID', null);
 	}
-	
+
 	function alternateAbsoluteLink() {
 		// Generate the existing absolute URL and replace the domain with the subsite domain.
 		// This helps deal with Link() returning an absolute URL.
@@ -221,7 +221,30 @@ class SiteTreeSubsites extends DataExtension {
 		}
 		return $url;
 	}
-	
+
+	/**
+	 * Use the CMS domain for iframed CMS previews to prevent single-origin violations
+	 * and SSL cert problems.
+	 */
+	function alternatePreviewLink($action = null) {
+		$url = Director::absoluteURL($this->owner->Link());
+		if($this->owner->SubsiteID) {
+			$url = HTTP::setGetVar('SubsiteID', $this->owner->SubsiteID, $url);
+		}
+		return $url;
+	}
+
+	/**
+	 * Inject the subsite ID into the content so it can be used by frontend scripts.
+	 */
+	function MetaTags(&$tags) {
+		if($this->owner->SubsiteID) {
+			$tags .= "<meta name=\"x-subsite-id\" content=\"" . $this->owner->SubsiteID . "\" />\n";
+		}
+
+		return $tags;
+	}
+
 	function augmentSyncLinkTracking() {
 		// Set LinkTracking appropriately
 		$links = HTTP::getLinksIn($this->owner->Content);

--- a/javascript/LeftAndMain_Subsites.js
+++ b/javascript/LeftAndMain_Subsites.js
@@ -57,4 +57,49 @@
 		});
 
 	});
+
+	$.entwine('ss.preview', function($){
+
+		$('.cms-preview').entwine({
+
+			/**
+			 * Update links and forms with GET/POST SubsiteID param, so we remaing on the current subsite.
+			 * The initial link for the iframe comes from SiteTreeSubsites::alternatePreviewLink.
+			 *
+			 * This is done so we can use the CMS domain for displaying previews so we prevent single-origin
+			 * violations and SSL cert problems that come up when iframing content from a different URL.
+			 */
+			onafterIframeAdjustedForPreview: function(event, doc) {
+				var subsiteId = $(doc).find('meta[name=x-subsite-id]').attr('content');
+
+				if (!subsiteId) return;
+
+				// Inject the SubsiteID into internal links.
+				$(doc).find('a').each(function() {
+					var href = $(this).attr('href');
+
+					if (!href.match(/^http:\/\//)) {
+
+						$(this).attr('href', $.path.addSearchParams(href, {
+							'SubsiteID': subsiteId
+						}));
+
+					}
+				});
+
+				// Inject the SubsiteID as a hidden input into all forms submitting to the local site.
+				$(doc).find('form').each(function() {
+
+					if (!$(this).attr('action').match(/^http:\/\//)) {
+						$(doc).find('form').append('<input type=hidden name="SubsiteID" value="' + subsiteId + '" >');
+					}
+
+				});
+
+			}
+
+		});
+
+	});
+
 })(jQuery);


### PR DESCRIPTION
Use the CMS domain for fetching the preview content to avoid SSL
errors and single-origin violations on the iframe.
