### PR TITLE
BUGFIX: Session var for active subsite out of sync with current subsite.

### DIFF
--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -9,6 +9,10 @@ class LeftAndMainSubsites extends Extension {
 	private static $allowed_actions = array('CopyToSubsite');
 
 	function init() {
+
+		//Use the session variable for current subsite in the CMS only
+		Subsite::$use_session_subsiteid = true;
+
 		Requirements::css('subsites/css/LeftAndMain_Subsites.css');
 		Requirements::javascript('subsites/javascript/LeftAndMain_Subsites.js');
 		Requirements::javascript('subsites/javascript/VirtualPage_Subsites.js');

--- a/code/extensions/SiteTreeSubsites.php
+++ b/code/extensions/SiteTreeSubsites.php
@@ -198,18 +198,8 @@ class SiteTreeSubsites extends DataExtension {
 	 * Called by ContentController::init();
 	 */
 	static function contentcontrollerInit($controller) {
-		// Need to set the SubsiteID to null incase we've been in the CMS
-		Session::set('SubsiteID', null);
 		$subsite = Subsite::currentSubsite();
 		if($subsite && $subsite->Theme) SSViewer::set_theme(Subsite::currentSubsite()->Theme);
-	}
-	
-	/**
-	 * Called by ModelAsController::init();
-	 */
-	static function modelascontrollerInit($controller) {
-		// Need to set the SubsiteID to null incase we've been in the CMS
-		Session::set('SubsiteID', null);
 	}
 
 	function alternateAbsoluteLink() {

--- a/code/model/Subsite.php
+++ b/code/model/Subsite.php
@@ -8,6 +8,12 @@
 class Subsite extends DataObject implements PermissionProvider {
 
 	/**
+	 * @var $use_session_subsiteid Boolean Set to true when using the CMS and false
+	 * when browsing the frontend of a website.
+	 */
+	public static $use_session_subsiteid = false;
+
+	/**
 	 * @var boolean $disable_subsite_filter If enabled, bypasses the query decoration
 	 * to limit DataObject::get*() calls to a specific subsite. Useful for debugging.
 	 */
@@ -286,12 +292,15 @@ JS;
 	 * @return int ID of the current subsite instance
 	 */
 	static function currentSubsiteID() {
-		if(isset($_GET['SubsiteID'])) $id = (int)$_GET['SubsiteID'];
-		else $id = Session::get('SubsiteID');
+		if(isset($_GET['SubsiteID'])) {
+			$id = (int)$_GET['SubsiteID'];
+		}
+		else if (Subsite::$use_session_subsiteid) {
+			$id = Session::get('SubsiteID');
+		} 
 
 		if($id === NULL) {
 			$id = self::getSubsiteIDForDomain();
-			Session::set('SubsiteID', $id);
 		}
 
 		return (int)$id;


### PR DESCRIPTION
Refs silverstripe/silverstripe-subsites#93.

Subsite ID is set in the session for use in the CMS only, frontend pages no longer inspect the session variable for the subsite ID at all. Frontend pages first look for SubsiteID in the URL, then find the subsite ID based on the current domain.

When page preview is rendered in the CMS the SubsiteID is passed via the URL.

I have tidied up this pull request so that the previous one could be closed without being merged.
