### PR TITLE
BUG Subsites selection on SubsitesVirtualPage (fixes #45 and #47)

### DIFF
--- a/code/SubsitesVirtualPage.php
+++ b/code/SubsitesVirtualPage.php
@@ -22,15 +22,13 @@ class SubsitesVirtualPage extends VirtualPage {
 		
 		$subsites->push(new ArrayData(array('Title' => 'Main site', 'ID' => 0)));
 
-		$subsiteSelectionField = new DropdownField(
-			"CopyContentFromID_SubsiteID", 
-			_t('SubsitesVirtualPage.SubsiteField',"Subsite"), 
-			$subsites->map('ID', 'Title'),
-			($this->CopyContentFromID) ? $this->CopyContentFrom()->SubsiteID : Session::get('SubsiteID')
-		);
 		$fields->addFieldToTab(
 			'Root.Main',
-			$subsiteSelectionField,
+			DropdownField::create(
+				"CopyContentFromID_SubsiteID", 
+				_t('SubsitesVirtualPage.SubsiteField',"Subsite"),  
+				$subsites->map('ID', 'Title')
+			)->addExtraClass('subsitestreedropdownfield-chooser no-change-track'),
 			'CopyContentFromID'
 		);
 		
@@ -44,7 +42,7 @@ class SubsitesVirtualPage extends VirtualPage {
 		);
 		
 		if(Controller::has_curr() && Controller::curr()->getRequest()) {
-			$subsiteID = Controller::curr()->getRequest()->postVar('CopyContentFromID_SubsiteID');
+			$subsiteID = Controller::curr()->getRequest()->requestVar('CopyContentFromID_SubsiteID');
 			$pageSelectionField->setSubsiteID($subsiteID);
 		}
 		$fields->replaceField('CopyContentFromID', $pageSelectionField);
@@ -110,6 +108,10 @@ class SubsitesVirtualPage extends VirtualPage {
 		$labels['CustomExtraMeta'] = _t('Subsite.CustomExtraMeta','Custom Meta Tags');
 
 		return $labels;
+	}
+
+	public function getCopyContentFromID_SubsiteID() {
+		return ($this->CopyContentFromID) ? (int)$this->CopyContentFrom()->SubsiteID : (int)Session::get('SubsiteID');
 	}
 	
 	public function getVirtualFields() {

--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -217,7 +217,11 @@ class LeftAndMainSubsites extends Extension {
 			// Update current subsite in session
 			Subsite::changeSubsite($_GET['SubsiteID']);
 
-			//Redirect to clear the current page
+			if ($this->owner->canView(Member::currentUser())) {
+				//Redirect to clear the current page
+				return $this->owner->redirect($this->owner->Link());
+			}
+			//Redirect to the default CMS section
 			return $this->owner->redirect('admin/');
 		}
 
@@ -230,7 +234,11 @@ class LeftAndMainSubsites extends Extension {
 				// Update current subsite in session
 				Subsite::changeSubsite($record->SubsiteID);
 
-				//Redirect to clear the current page
+				if ($this->owner->canView(Member::currentUser())) {
+					//Redirect to clear the current page
+					return $this->owner->redirect($this->owner->Link());
+				}
+				//Redirect to the default CMS section
 				return $this->owner->redirect('admin/');
 			}
 

--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -207,21 +207,6 @@ class LeftAndMainSubsites extends Extension {
 
 		// FIRST, check if we need to change subsites due to the URL.
 
-		// Automatically redirect the session to appropriate subsite when requesting a record.
-		// This is needed to properly initialise the session in situations where someone opens the CMS via a link.
-		$record = $this->owner->currentPage();
-		if($record && isset($record->SubsiteID) && is_numeric($record->SubsiteID)) {
-
-			if ($this->shouldChangeSubsite($this->owner->class, $record->SubsiteID, Subsite::currentSubsiteID())) {
-				// Update current subsite in session
-				Subsite::changeSubsite($record->SubsiteID);
-
-				//Redirect to clear the current page
-				return $this->owner->redirect('admin/');
-			}
-
-		}
-
 		// Catch forced subsite changes that need to cause CMS reloads.
 		if(isset($_GET['SubsiteID'])) {
 			// Clear current page when subsite changes (or is set for the first time)
@@ -234,6 +219,21 @@ class LeftAndMainSubsites extends Extension {
 
 			//Redirect to clear the current page
 			return $this->owner->redirect('admin/');
+		}
+
+		// Automatically redirect the session to appropriate subsite when requesting a record.
+		// This is needed to properly initialise the session in situations where someone opens the CMS via a link.
+		$record = $this->owner->currentPage();
+		if($record && isset($record->SubsiteID) && is_numeric($record->SubsiteID) && isset($this->owner->urlParams['ID'])) {
+
+			if ($this->shouldChangeSubsite($this->owner->class, $record->SubsiteID, Subsite::currentSubsiteID())) {
+				// Update current subsite in session
+				Subsite::changeSubsite($record->SubsiteID);
+
+				//Redirect to clear the current page
+				return $this->owner->redirect('admin/');
+			}
+
 		}
 
 		// SECOND, check if we need to change subsites due to lack of permissions.

--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -217,12 +217,10 @@ class LeftAndMainSubsites extends Extension {
 			// Update current subsite in session
 			Subsite::changeSubsite($_GET['SubsiteID']);
 
-			if ($this->owner->canView(Member::currentUser())) {
-				//Redirect to clear the current page
-				return $this->owner->redirect($this->owner->Link());
+			if (!$this->owner->canView(Member::currentUser())) {
+				//Redirect to the default CMS section
+				return $this->owner->redirect('admin/');
 			}
-			//Redirect to the default CMS section
-			return $this->owner->redirect('admin/');
 		}
 
 		// Automatically redirect the session to appropriate subsite when requesting a record.
@@ -234,12 +232,10 @@ class LeftAndMainSubsites extends Extension {
 				// Update current subsite in session
 				Subsite::changeSubsite($record->SubsiteID);
 
-				if ($this->owner->canView(Member::currentUser())) {
-					//Redirect to clear the current page
-					return $this->owner->redirect($this->owner->Link());
+				if (!$this->owner->canView(Member::currentUser())) {
+					//Redirect to the default CMS section
+					return $this->owner->redirect('admin/');
 				}
-				//Redirect to the default CMS section
-				return $this->owner->redirect('admin/');
 			}
 
 		}

--- a/javascript/SubsitesTreeDropdownField.js
+++ b/javascript/SubsitesTreeDropdownField.js
@@ -1,24 +1,30 @@
 (function($) {
 	$.entwine('ss', function($) {
-		$('.TreeDropdownField').entwine({
-			subsiteID: function() {
-				var subsiteSel = $('#CopyContentFromID_SubsiteID select')[0];
-				if(!subsiteSel) return;
-				
-				subsiteSel.onchange = (function() {
-					this.createTreeNode(true);
-					this.ajaxGetTree((function(response) {
-						this.newTreeReady(response, true);
-						this.updateTreeLabel();
-					}).bind(this));
-				}).bind(this);
-				return subsiteSel.options[subsiteSel.selectedIndex].value;
-			},
-	
+		/**
+		 * Choose a subsite from which to select pages.
+		 * Needs to clear tree dropdowns in case selection is changed.
+		 */
+		$('.subsitestreedropdownfield-chooser').entwine({
+			onchange: function() {
+				// TODO Data binding between two fields
+				// TODO create resetField method on API instead
+				var fields = $('.SubsitesTreeDropdownField');
+				fields.setValue(null);
+				fields.setTitle(null);
+				fields.find('.tree-holder').empty();
+			}
+		});
+
+		/**
+		 * Add selected subsite from separate dropdown to the request parameters
+		 * before asking for the tree.
+		 */
+		$('.TreeDropdownField.SubsitesTreeDropdownField').entwine({
 			getRequestParams: function() {
-				var name = this.find(':input:hidden').attr('name'), obj = {};
-				obj[name + '_SubsiteID'] = parseInt(this.subsiteID());
-				return obj;
+				var name = this.find(':input[type=hidden]:first').attr('name') + '_SubsiteID',
+					source = $('[name=' + name + ']'), params = {};
+				params[name] = source.length ? source.val() : null;
+				return params;
 			}
 		});
 	});

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,8 +1,4 @@
 en:
-  SubsiteAdmin:
-    MENUTITLE: Subsites
-  SubsiteXHRController:
-    MENUTITLE: SubsiteXHRController
   ASSETADMIN:
     SUBSITENOTICE: 'Folders and files created in the main site are accessible by all subsites.'
   FileSubsites:
@@ -20,6 +16,9 @@ en:
     SECURITYTABTITLE: Subsites
   LeftAndMainSubsites:
     Saved: 'Saved, please update related pages.'
+  LeftAndMain_Menu:
+    Hello: Hi
+    LOGOUT: 'Log out'
   SiteTreeSubsites:
     CopyAction: Copy
     CopyToSubsite: 'Copy page to subsite'
@@ -42,6 +41,8 @@ en:
     SiteConfigTitle: 'Your Site Name'
     TabTitleConfig: Configuration
     ValidateTitle: 'Please add a "Title"'
+  SubsiteAdmin:
+    MENUTITLE: Subsites
   SubsiteDomain:
     DOMAIN: Domain
     IS_PRIMARY: 'Is Primary Domain'
@@ -49,6 +50,8 @@ en:
     SINGULARNAME: 'Subsite Domain'
   SubsiteReportWrapper:
     ReportDropdown: Sites
+  SubsiteXHRController:
+    MENUTITLE: SubsiteXHRController
   Subsites:
     DefaultSiteFieldLabel: 'Default site'
     DomainFieldLabel: Domain
@@ -62,6 +65,8 @@ en:
     TitleFieldLabel: 'Subsite Name'
   SubsitesVirtualPage:
     DESCRIPTION: 'Displays the content of a page on another subsite'
-    PLURALNAME: 'Subsites Virtual Pages'
+    PLURALNAME: 'Base Pages'
     SINGULARNAME: 'Subsites Virtual Page'
     SubsiteField: Subsite
+  VirtualPage:
+    EDITCONTENT: 'Click here to edit the content'

--- a/lang/id.yml
+++ b/lang/id.yml
@@ -1,0 +1,19 @@
+id:
+  SubsiteAdmin:
+    MENUTITLE: Subsitus
+  FileSubsites:
+    SubsiteFieldLabel: Subsitus
+  GroupSubsites:
+    SECURITYTABTITLE: Subsitus
+  Subsite:
+    CustomMetaDescription: Deskripsi
+    CustomMetaKeywords: Kata kunci
+    CustomMetaTitle: Judul
+    PLURALNAME: Subsitus
+    SINGULARNAME: Subsitus
+  SubsiteReportWrapper:
+    ReportDropdown: Situs
+  Subsites:
+    LanguageFieldLabel: Bahasa
+  SubsitesVirtualPage:
+    SubsiteField: Subsitus

--- a/tests/SiteTreeSubsitesTest.php
+++ b/tests/SiteTreeSubsitesTest.php
@@ -8,6 +8,10 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 		'SiteTreeSubsitesTest_ClassA',
 		'SiteTreeSubsitesTest_ClassB'
 	);
+
+	protected $illegalExtensions = array(
+		'SiteTree' => array('Translatable')
+	);
 	
 	function testPagesInDifferentSubsitesCanShareURLSegment() {
 		$subsiteMain = $this->objFromFixture('Subsite', 'main');
@@ -129,7 +133,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 	}
 	
 	function testPageTypesBlacklistInClassDropdown() {
-		Session::set("loggedInAs", null);
+		$this->logInWithPermission('CMS_ACCESS_CMSMain');
 		
 		$s1 = $this->objFromFixture('Subsite','domaintest1');
 		$s2 = $this->objFromFixture('Subsite','domaintest2');
@@ -164,7 +168,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 	}
 	
 	function testPageTypesBlacklistInCMSMain() {
-		Session::set("loggedInAs", null);
+		$this->logInWithPermission('CMS_ACCESS_CMSMain');
 		
 		$cmsmain = new CMSMain();
 		
@@ -175,16 +179,18 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 		$s1->write();
 
 		Subsite::changeSubsite($s1);
-		$classes = $cmsmain->PageTypes()->column('ClassName');
-		$this->assertNotContains('ErrorPage', $classes);
-		$this->assertNotContains('SiteTreeSubsitesTest_ClassA', $classes);
-		$this->assertContains('SiteTreeSubsitesTest_ClassB', $classes);
-
-		Subsite::changeSubsite($s2);
-		$classes = $cmsmain->PageTypes()->column("ClassName");
+		$hints = Convert::json2array($cmsmain->SiteTreeHints());
+		$classes = $hints['Root']['disallowedChildren'];
 		$this->assertContains('ErrorPage', $classes);
 		$this->assertContains('SiteTreeSubsitesTest_ClassA', $classes);
-		$this->assertContains('SiteTreeSubsitesTest_ClassB', $classes);
+		$this->assertNotContains('SiteTreeSubsitesTest_ClassB', $classes);
+
+		Subsite::changeSubsite($s2);
+		$hints = Convert::json2array($cmsmain->SiteTreeHints());
+		$classes = $hints['Root']['disallowedChildren'];
+		$this->assertNotContains('ErrorPage', $classes);
+		$this->assertNotContains('SiteTreeSubsitesTest_ClassA', $classes);
+		$this->assertNotContains('SiteTreeSubsitesTest_ClassB', $classes);
 	}
 	
 }


### PR DESCRIPTION
There's still too much coupling between the two form fields, but the treedropdown can operate independently now.
This also fixes some plain broken code which uses 2.x TreeDropdown APIs, and removes usage of behaviour.js style `$$()` which was removed from 3.1.