### PR TITLE
API: Subsite support for menu of cms (hides admins that don't declare support) (fixes #101 and #89 )

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -17,3 +17,12 @@ ErrorPage::add_extension('ErrorPageSubsite');
 SiteConfig::add_extension('SiteConfigSubsites');
 
 SS_Report::add_excluded_reports('SubsiteReportWrapper');
+
+//Display in cms menu
+AssetAdmin::add_extension('SubsiteMenuExtension');
+SecurityAdmin::add_extension('SubsiteMenuExtension');
+CMSMain::add_extension('SubsiteMenuExtension');
+CMSPagesController::add_extension('SubsiteMenuExtension');
+SubsiteAdmin::add_extension('SubsiteMenuExtension');
+CMSSettingsController::add_extension('SubsiteMenuExtension');
+

--- a/code/SubsiteAdmin.php
+++ b/code/SubsiteAdmin.php
@@ -29,4 +29,18 @@ class SubsiteAdmin extends ModelAdmin {
 
 		return $form;
 	}
+
+	public function getResponseNegotiator() {
+		$negotiator = parent::getResponseNegotiator();
+		$self = $this;
+		// Register a new callback
+		$negotiator->setCallback('SubsiteList', function() use(&$self) {
+			return $self->SubsiteList();
+		});
+		return $negotiator;
+	}
+
+	public function SubsiteList() {
+		return $this->renderWith('SubsiteList');
+	}
 }

--- a/code/extensions/FileSubsites.php
+++ b/code/extensions/FileSubsites.php
@@ -35,7 +35,17 @@ class FileSubsites extends DataExtension {
 				$values[$site->ID] = $site->Title;
 			}
 			ksort($values);
-			if($sites)$fields->push(new DropdownField('SubsiteID', 'Subsite', $values));
+			if($sites){
+				//Dropdown needed to move folders between subsites
+				$fields->push($dropdown = new DropdownField('SubsiteID', 'Subsite', $values));
+				$fields->push(new LiteralField(
+					'Message', 
+					'<p class="message notice">'.
+					_t('ASSETADMIN.SUBSITENOTICE', 'Folders and files created in the main site are accessible by all subsites.')
+					.'</p>'
+				));
+				$dropdown->addExtraClass('subsites-move-dropdown');
+			}
 		}
 	}
 

--- a/code/extensions/SubsiteMenuExtension.php
+++ b/code/extensions/SubsiteMenuExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Simple extension to show admins in the menu of subsites.
+ * If an admin area should be available to a subsite, you can attach 
+ * this class to your admin in config. eg:
+ *
+ * 		MyAdmin::add_extension('SubsiteMenuExtension');
+ *
+ * Or you can include the subsiteCMSShowInMenu function in your admin class and have it return true
+ */
+
+class SubsiteMenuExtension extends Extension{
+	
+	public function subsiteCMSShowInMenu(){
+		return true;
+	}
+
+}

--- a/code/model/Subsite.php
+++ b/code/model/Subsite.php
@@ -219,7 +219,7 @@ class Subsite extends DataObject implements PermissionProvider {
 		asort($pageTypeMap);
 
 		$fields = new FieldList(
-			new TabSet('Root',
+			$subsiteTabs = new TabSet('Root',
 				new Tab('Configuration',
 					new HeaderField($this->getClassName() . ' configuration', 2),
 					new TextField('Title', 'Name of subsite:', $this->Title),
@@ -251,6 +251,8 @@ class Subsite extends DataObject implements PermissionProvider {
 			new HiddenField('ID', '', $this->ID),
 			new HiddenField('IsSubsite', '', 1)
 		);
+
+		$subsiteTabs->addExtraClass('subsite-model');
 
 		$this->extend('updateCMSFields', $fields);
 		return $fields;

--- a/css/LeftAndMain_Subsites.css
+++ b/css/LeftAndMain_Subsites.css
@@ -81,3 +81,11 @@ body.SubsiteAdmin .right form #URL .fieldgroup * {
 .cms-add-form #PageType li .class-SubsitesVirtualPage, .class-SubsitesVirtualPage a .jstree-pageicon {
 	background-position: 0 -32px !important;
 }
+
+.subsites-move-dropdown{
+	display:none;
+}
+
+#Root_DetailsView .subsites-move-dropdown{
+	display:block;
+}

--- a/templates/Includes/SubsiteList.ss
+++ b/templates/Includes/SubsiteList.ss
@@ -1,0 +1,9 @@
+<div class="cms-subsites" data-pjax-fragment="SubsiteList">
+	<div class="field dropdown">
+		<select id="SubsitesSelect">
+			<% loop $ListSubsites %>
+				<option value="$ID" $CurrentState>$Title</option>
+			<% end_loop %>
+		</select>
+	</div>
+</div>

--- a/templates/LeftAndMain_Menu.ss
+++ b/templates/LeftAndMain_Menu.ss
@@ -2,33 +2,32 @@
 	<div class="cms-logo-header north">
 		<div class="cms-logo">
 			<a href="$ApplicationLink" target="_blank" title="$ApplicationName (Version - $CMSVersion)">
-				$ApplicationName <% if CMSVersion %><abbr class="version">$CMSVersion</abbr><% end_if %>
+				$ApplicationName <% if $CMSVersion %><abbr class="version">$CMSVersion</abbr><% end_if %>
 			</a>
-			<span><% if SiteConfig %>$SiteConfig.Title<% else %>$ApplicationName<% end_if %></span>
+			<span><% if $SiteConfig %>$SiteConfig.Title<% else %>$ApplicationName<% end_if %></span>
 		</div>
 	
 		<div class="cms-login-status">
 			<a href="Security/logout" class="logout-link" title="<% _t('LeftAndMain_Menu.ss.LOGOUT','Log out') %>"><% _t('LeftAndMain_Menu.ss.LOGOUT','Log out') %></a>
-			<% with CurrentMember %>
+			<% with $CurrentMember %>
 				<span>
 					<% _t('LeftAndMain_Menu.ss.Hello','Hi') %>
-					<a href="{$AbsoluteBaseURL}admin/myprofile" class="profile-link ss-ui-dialog-link" data-popupclass="edit-profile-popup">
-						<% if FirstName && Surname %>$FirstName $Surname<% else_if FirstName %>$FirstName<% else %>$Email<% end_if %>
+					<a href="{$AbsoluteBaseURL}admin/myprofile" class="profile-link">
+						<% if $FirstName && $Surname %>$FirstName $Surname<% else_if $FirstName %>$FirstName<% else %>$Email<% end_if %>
 					</a>
 				</span>
 			<% end_with %>
 		</div>
-
-		<div class="cms-subsites">
-			$SubsiteList
-		</div>
+		<% if $ListSubsites %>
+			<% include SubsiteList %>
+		<% end_if %>
 	</div>
 		
 	<div class="cms-panel-content center">
 		<ul class="cms-menu-list">
-		<% loop MainMenu %>
-			<li class="$LinkingMode $FirstLast <% if LinkingMode == 'link' %><% else %>opened<% end_if %>" id="Menu-$Code" title="$Title.ATT">
-				<a href="$Link" <% if Code == 'Help' %>target="_blank"<% end_if%>>
+		<% loop $SubsiteMainMenu %>
+			<li class="$LinkingMode $FirstLast <% if $LinkingMode == 'link' %><% else %>opened<% end_if %>" id="Menu-$Code" title="$Title.ATT">
+				<a href="$Link" <% if $Code == 'Help' %>target="_blank"<% end_if %>>
 					<span class="icon icon-16 icon-{$Code.LowerCase}">&nbsp;</span>
 					<span class="text">$Title</span>
 				</a>


### PR DESCRIPTION
- Hide admins without subsite support from subsites menu
- Add subsite support to default site areas
- Enable reloading of subsites switcher dropdown when navigating the
  site, and when editing subsite areas
- Removed area based options from subsite menu, as it confused the ui. Put a message in the files area to explain global nature of files in main site.

Also relates to #85 as it now seems more appropriate to do a hard refresh when changing sites (at least between main and subsites).

Tested on IE8, Chrome, and Firefox
