### PR TITLE
FIX: Make Subsites work correctly with ChangeTracker ignoreFieldSelector option

### DIFF
--- a/javascript/LeftAndMain_Subsites.js
+++ b/javascript/LeftAndMain_Subsites.js
@@ -106,8 +106,8 @@
 		});
 		
 		$('.cms-edit-form').entwine({
-			getChangeTrackerOptions: function() {
-				this.ChangeTrackerOptions.ignoreFieldSelector+=', input[name=IsSubsite]';
+			ChangeTrackerOptions: {
+				ignoreFieldSelector: '.no-change-track, .ss-upload :input, .cms-navigator :input, input[name=IsSubsite]'
 			}
 		});
 		


### PR DESCRIPTION
Currently the `getChangeTrackerOptions` method is used to overload the `ignoreFieldSelector`. However this doesn't pull through the value from `LeftAndMain.EditForm.js` so it is necessary to redeclare it.

I've done it this way because I couldn't figure out a decent way to use the `getChangeTrackerOptions` method. That being said I'm not an entwine/js expert so am happy to be shown a better way of fixing this.
