### PR TITLE
BUG Prevent session-interface mismatch.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,6 @@
+---
+Name: mysiteconfig
+After: 'framework/*','cms/*'
+---
+AssetAdmin:
+  treats_subsite_0_as_global: true

--- a/tests/LeftAndMainSubsitesTest.php
+++ b/tests/LeftAndMainSubsitesTest.php
@@ -66,4 +66,23 @@ class LeftAndMainSubsitesTest extends FunctionalTest {
 		
 	}
 
+	function testShouldChangeSubsite() {
+		$l = new LeftAndMain();
+		Config::inst()->nest();
+
+		Config::inst()->update('CMSPageEditController', 'treats_subsite_0_as_global', false);
+		$this->assertTrue($l->shouldChangeSubsite('CMSPageEditController', 0, 5));
+		$this->assertFalse($l->shouldChangeSubsite('CMSPageEditController', 0, 0));
+		$this->assertTrue($l->shouldChangeSubsite('CMSPageEditController', 1, 5));
+		$this->assertFalse($l->shouldChangeSubsite('CMSPageEditController', 1, 1));
+
+		Config::inst()->update('CMSPageEditController', 'treats_subsite_0_as_global', true);
+		$this->assertFalse($l->shouldChangeSubsite('CMSPageEditController', 0, 5));
+		$this->assertFalse($l->shouldChangeSubsite('CMSPageEditController', 0, 0));
+		$this->assertTrue($l->shouldChangeSubsite('CMSPageEditController', 1, 5));
+		$this->assertFalse($l->shouldChangeSubsite('CMSPageEditController', 1, 1));
+
+		Config::inst()->unnest();
+	}
+
 }


### PR DESCRIPTION
Disables transparent subsite switch on AJAX requests.

Makes sure the subsite is appropriately set up when opening up the CMS
with a link to subsited object. Also adds options to flexibly
configure this depending if the object is attached to main site/any
site.
