### PR TITLE
FIX: Ensure that ChangeTrackerOptions doesn't get overriden

### DIFF
--- a/javascript/LeftAndMain_Subsites.js
+++ b/javascript/LeftAndMain_Subsites.js
@@ -106,8 +106,27 @@
 		});
 		
 		$('.cms-edit-form').entwine({
+			/**
+			 * TODO: Fix with Entwine API extension. See https://github.com/silverstripe/silverstripe-subsites/pull/125
+			 */
 			getChangeTrackerOptions: function() {
-				this.ChangeTrackerOptions.ignoreFieldSelector+=', input[name=IsSubsite]';
+				// Figure out if we're still returning the default value
+				var isDefault = (this.entwineData('ChangeTrackerOptions') === undefined);
+				// Get the current options
+				var opts = this._super();
+
+				if (isDefault) {
+					// If it is the default then...
+					// clone the object (so we don't modify the original),
+					var opts = $.extend({}, opts);
+					// modify it,
+					opts.ignoreFieldSelector +=', input[name=IsSubsite]';
+					// then set the clone as the value on this element
+					// (so next call to this method gets this same clone)
+					this.setChangeTrackerOptions(opts);
+				}
+
+				return opts;
 			}
 		});
 		


### PR DESCRIPTION
Use `_super()` to reference parent getter in `LeftAndMain.EditForm.js` to ensure that `ChangeTrackerOptions` is modified and not overriden.

See #118 for initial bug report.
