### PR TITLE
BUG Refactor the access checks and initial subsite redirections.

### DIFF
--- a/code/SubsiteXHRController.php
+++ b/code/SubsiteXHRController.php
@@ -16,6 +16,13 @@ class SubsiteXHRController extends LeftAndMain {
 		return false;
 	}
 
+	/**
+	 * Similar as above, but for the LeftAndMainSubsites - allow access if user allowed into the CMS at all.
+	 */
+	public function canAccess() {
+		if (Subsite::all_accessible_sites()->count()>0) return true;
+	}
+
 	public function getResponseNegotiator() {
 		$negotiator = parent::getResponseNegotiator();
 		$self = $this;

--- a/tests/SubsiteAdminFunctionalTest.php
+++ b/tests/SubsiteAdminFunctionalTest.php
@@ -69,17 +69,17 @@ class SubsiteAdminFunctionalTest extends FunctionalTest {
 		Subsite::changeSubsite(0);
 		$this->getAndFollowAll("admin/pages/edit/show/$subsite1Home->ID");
 		$this->assertEquals(Subsite::currentSubsiteID(), $subsite1Home->SubsiteID, 'Loading an object switches the subsite');
-		$this->assertRegExp("#^admin/pages/edit/show/$subsite1Home->ID.*#", $this->mainSession->lastUrl(), 'Lands on the correct section');
+		$this->assertRegExp("#^admin/pages.*#", $this->mainSession->lastUrl(), 'Lands on the correct section');
 
 		Config::inst()->update('CMSPageEditController', 'treats_subsite_0_as_global', true);
 		Subsite::changeSubsite(0);
 		$this->getAndFollowAll("admin/pages/edit/show/$subsite1Home->ID");
 		$this->assertEquals(Subsite::currentSubsiteID(), $subsite1Home->SubsiteID, 'Loading a non-main-site object still switches the subsite if configured with treats_subsite_0_as_global');
-		$this->assertRegExp("#^admin/pages/edit/show/$subsite1Home->ID.*#", $this->mainSession->lastUrl(), 'Lands on the correct section');
+		$this->assertRegExp("#^admin/pages.*#", $this->mainSession->lastUrl(), 'Lands on the correct section');
 
 		$this->getAndFollowAll("admin/pages/edit/show/$mainSubsitePage->ID");
 		$this->assertNotEquals(Subsite::currentSubsiteID(), $mainSubsitePage->SubsiteID, 'Loading a main-site object does not change the subsite if configured with treats_subsite_0_as_global');
-		$this->assertRegExp("#^admin/pages/edit/show/$mainSubsitePage->ID.*#", $this->mainSession->lastUrl(), 'Lands on the correct section');
+		$this->assertRegExp("#^admin/pages.*#", $this->mainSession->lastUrl(), 'Lands on the correct section');
 
 		Config::inst()->unnest();
 	}


### PR DESCRIPTION
Remove the special AJAX handling to simplify the code. Now redirection
will be forced on any request that changes the subsite to re-synchronise
with the frontend.

Introduce canAccess method, and add it to alternateAccessCheck to make
sure this subsite-specific chceck is also done in situations that are
not captured by onBeforeInit.
