### PR TITLE
provide DataExtensions hook for summaryFields()

### DIFF
--- a/code/model/Subsite.php
+++ b/code/model/Subsite.php
@@ -629,11 +629,13 @@ class Subsite extends DataObject implements PermissionProvider {
 	 * @return array
 	 */
 	public function summaryFields() {
-		return array(
+		$fields = array(
 			'Title' => $this->fieldLabel('Title'),
 			'PrimaryDomain' => $this->fieldLabel('PrimaryDomain'),
 			'IsPublic' => _t('Subsite.IsPublicHeaderField','Active subsite'),
 		);
+		$this->extend("updateSummaryFields", $fields);
+		return $fields;
 	}
 	
 	/**


### PR DESCRIPTION
silverstripe/silverstripe-subsites#137: allow DataExtensions to change the summaryFields