### PR TITLE
Fixes #135: LeftAndMain switching between subsites

### DIFF
--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -207,21 +207,6 @@ class LeftAndMainSubsites extends Extension {
 
 		// FIRST, check if we need to change subsites due to the URL.
 
-		// Automatically redirect the session to appropriate subsite when requesting a record.
-		// This is needed to properly initialise the session in situations where someone opens the CMS via a link.
-		$record = $this->owner->currentPage();
-		if($record && isset($record->SubsiteID) && is_numeric($record->SubsiteID)) {
-
-			if ($this->shouldChangeSubsite($this->owner->class, $record->SubsiteID, Subsite::currentSubsiteID())) {
-				// Update current subsite in session
-				Subsite::changeSubsite($record->SubsiteID);
-
-				//Redirect to clear the current page
-				return $this->owner->redirect('admin/');
-			}
-
-		}
-
 		// Catch forced subsite changes that need to cause CMS reloads.
 		if(isset($_GET['SubsiteID'])) {
 			// Clear current page when subsite changes (or is set for the first time)
@@ -234,6 +219,21 @@ class LeftAndMainSubsites extends Extension {
 
 			//Redirect to clear the current page
 			return $this->owner->redirect('admin/');
+		}
+
+		// Automatically redirect the session to appropriate subsite when requesting a record.
+		// This is needed to properly initialise the session in situations where someone opens the CMS via a link.
+		$record = $this->owner->currentPage();
+		if($record && isset($record->SubsiteID) && is_numeric($record->SubsiteID) && isset($this->owner->urlParams['ID'])) {
+
+			if ($this->shouldChangeSubsite($this->owner->class, $record->SubsiteID, Subsite::currentSubsiteID())) {
+				// Update current subsite in session
+				Subsite::changeSubsite($record->SubsiteID);
+
+				//Redirect to clear the current page
+				return $this->owner->redirect('admin/');
+			}
+
 		}
 
 		// SECOND, check if we need to change subsites due to lack of permissions.


### PR DESCRIPTION
When trying to switch to a different subsite from a page's editing view, it wouldn't switch. This was partly due to a $record always existing due to the homepage fallback on currentPageID : https://github.com/silverstripe/silverstripe-cms/blob/3.1/code/controllers/CMSMain.php#L816

So as `currentPage()` couldn't actually be used to test for the existance of a current page, I've added in a check for `isset($this->owner->urlParams['ID'])`.

I've also moved the check for `$_GET['SubsiteID’]` which indicated a forced subsite switch (eg. via the dropdown switcher) above the check for a current page, as it should take precedence, and it wasn't being run when both conditions matched causing the subsite not to change.

Tested changing subsites from /admin/pages, from page edit view, from a page edit URL, and from other CMS sections such as Files and Security, and all seems to be working perfectly now.
