### PR TITLE
BUG: The move to subsite folder dropdown in files is gone

### DIFF
--- a/css/LeftAndMain_Subsites.css
+++ b/css/LeftAndMain_Subsites.css
@@ -90,6 +90,6 @@ body.SubsiteAdmin .right form #URL .fieldgroup * {
 	display:none;
 }
 
-#Root_DetailsView .subsites-move-dropdown{
+#Form_ItemEditForm .subsites-move-dropdown{
 	display:block;
 }


### PR DESCRIPTION
I think the hiding of the dropdown and later re-enable from https://github.com/silverstripe/silverstripe-subsites/issues/68 from  #101 and #89 is broken and later the form name changed?

