### PR TITLE
Removing unused permission SUBSITE_ASSETS_CREATE_SUBSITE

### DIFF
--- a/code/model/Subsite.php
+++ b/code/model/Subsite.php
@@ -5,7 +5,7 @@
  *
  * @package subsites
  */
-class Subsite extends DataObject implements PermissionProvider {
+class Subsite extends DataObject {
 
 	/**
 	 * @var $use_session_subsiteid Boolean Set to TRUE when using the CMS and FALSE
@@ -511,22 +511,7 @@ class Subsite extends DataObject implements PermissionProvider {
 	public function canEdit($member = false) {
 		return true;
 	}
-	
-	/**
-	 * 
-	 * @return array
-	 */
-	public function providePermissions() {
-		return array(
-			'SUBSITE_ASSETS_CREATE_SUBSITE' => array(
-				'name' => _t('Subsite.MANAGE_ASSETS', 'Manage assets for subsites'),
-				'category' => _t('Permissions.PERMISSIONS_CATEGORY', 'Roles and access permissions'),
-				'help' => _t('Subsite.MANAGE_ASSETS_HELP', 'Ability to select the subsite to which an asset folder belongs. Requires "Access to Files & Images."'),
-				'sort' => 300
-			)
-		);
-	}
-	
+
 	/**
 	 * Show the configuration fields for each subsite
 	 * 


### PR DESCRIPTION
This isn't used, according to the description it would limit the list
of subsites you can choose to apply a File/Folder to. However, this
dropdown is shown to the user based on whether they have access to
that subsite, so this unused permission code isn't needed.

I checked the old 0.3 branch that works on SS 2.3 (quite old), and this
wasn't being used back then either... it's dead code :)

Note that tests failing don't have anything to do with this change, subsites master
is currently broken because of an API change in framework master with
augmentSQL. Passes for 3.1 though.
