### PR TITLE
Bugfix for urls with %27 in the url

### DIFF
--- a/code/extensions/SiteTreeSubsites.php
+++ b/code/extensions/SiteTreeSubsites.php
@@ -263,7 +263,7 @@ class SiteTreeSubsites extends DataExtension {
 
 					$origDisableSubsiteFilter = Subsite::$disable_subsite_filter;
 					Subsite::disable_subsite_filter(true);
-					$candidatePage = DataObject::get_one("SiteTree", "\"URLSegment\" = '" . urldecode( $rest). "' AND \"SubsiteID\" = " . $subsiteID, false);
+					$candidatePage = DataObject::get_one("SiteTree", "\"URLSegment\" = '" . Convert::raw2sql(urldecode( $rest)) . "' AND \"SubsiteID\" = " . $subsiteID, false);
 					Subsite::disable_subsite_filter($origDisableSubsiteFilter);
 					
 					if($candidatePage) {


### PR DESCRIPTION
I discovered a bug in the "augmentSyncLinkTracking" function by accident. I was working in the CMS and added a link to the page "http://en.wikipedia.org/wiki/Domino%27s_Pizza" as content. This resulted in a 500 error. This code change fixes the described problem.
