### PR TITLE
redirect_fix_between_CMS_sections

### DIFF
--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -217,7 +217,11 @@ class LeftAndMainSubsites extends Extension {
 			// Update current subsite in session
 			Subsite::changeSubsite($_GET['SubsiteID']);
 
-			//Redirect to clear the current page
+			if ($this->owner->canView(Member::currentUser())) {
+				//Redirect to clear the current page
+				return $this->owner->redirect($this->owner->Link());
+			}
+			//Redirect to the default CMS section
 			return $this->owner->redirect('admin/');
 		}
 
@@ -230,7 +234,11 @@ class LeftAndMainSubsites extends Extension {
 				// Update current subsite in session
 				Subsite::changeSubsite($record->SubsiteID);
 
-				//Redirect to clear the current page
+				if ($this->owner->canView(Member::currentUser())) {
+					//Redirect to clear the current page
+					return $this->owner->redirect($this->owner->Link());
+				}
+				//Redirect to the default CMS section
 				return $this->owner->redirect('admin/');
 			}
 


### PR DESCRIPTION
previously if you were editing settings and you changed subsites ti would revert you to /admin, now it stays within your current controller