### PR TITLE
FIX: Removed unnecessary redirect. 

### DIFF
--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -217,12 +217,10 @@ class LeftAndMainSubsites extends Extension {
 			// Update current subsite in session
 			Subsite::changeSubsite($_GET['SubsiteID']);
 
-			if ($this->owner->canView(Member::currentUser())) {
-				//Redirect to clear the current page
-				return $this->owner->redirect($this->owner->Link());
+			if (!$this->owner->canView(Member::currentUser())) {
+				//Redirect to the default CMS section
+				return $this->owner->redirect('admin/');
 			}
-			//Redirect to the default CMS section
-			return $this->owner->redirect('admin/');
 		}
 
 		// Automatically redirect the session to appropriate subsite when requesting a record.
@@ -234,12 +232,10 @@ class LeftAndMainSubsites extends Extension {
 				// Update current subsite in session
 				Subsite::changeSubsite($record->SubsiteID);
 
-				if ($this->owner->canView(Member::currentUser())) {
-					//Redirect to clear the current page
-					return $this->owner->redirect($this->owner->Link());
+				if (!$this->owner->canView(Member::currentUser())) {
+					//Redirect to the default CMS section
+					return $this->owner->redirect('admin/');
 				}
-				//Redirect to the default CMS section
-				return $this->owner->redirect('admin/');
 			}
 
 		}


### PR DESCRIPTION
This is early enough in the script that the correct subsite will be used from hereon.

The current subsite is also set prior to redirects based on the URL so the correct subsite is always set for the current page.

@pitchandtone this is on top of your fix. If you could find the time to double check it doesn't break what you fixed that would be much appreciated :+1: 