### PR TITLE
Fix subsites to use correct permissions

### DIFF
--- a/tests/SiteTreeSubsitesTest.php
+++ b/tests/SiteTreeSubsitesTest.php
@@ -8,6 +8,10 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 		'SiteTreeSubsitesTest_ClassA',
 		'SiteTreeSubsitesTest_ClassB'
 	);
+
+	protected $illegalExtensions = array(
+		'SiteTree' => array('Translatable')
+	);
 	
 	function testPagesInDifferentSubsitesCanShareURLSegment() {
 		$subsiteMain = $this->objFromFixture('Subsite', 'main');
@@ -129,7 +133,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 	}
 	
 	function testPageTypesBlacklistInClassDropdown() {
-		Session::set("loggedInAs", null);
+		$this->logInWithPermission('CMS_ACCESS_CMSMain');
 		
 		$s1 = $this->objFromFixture('Subsite','domaintest1');
 		$s2 = $this->objFromFixture('Subsite','domaintest2');
@@ -164,7 +168,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 	}
 	
 	function testPageTypesBlacklistInCMSMain() {
-		Session::set("loggedInAs", null);
+		$this->logInWithPermission('CMS_ACCESS_CMSMain');
 		
 		$cmsmain = new CMSMain();
 		
@@ -175,16 +179,18 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 		$s1->write();
 
 		Subsite::changeSubsite($s1);
-		$classes = $cmsmain->PageTypes()->column('ClassName');
-		$this->assertNotContains('ErrorPage', $classes);
-		$this->assertNotContains('SiteTreeSubsitesTest_ClassA', $classes);
-		$this->assertContains('SiteTreeSubsitesTest_ClassB', $classes);
-
-		Subsite::changeSubsite($s2);
-		$classes = $cmsmain->PageTypes()->column("ClassName");
+		$hints = Convert::json2array($cmsmain->SiteTreeHints());
+		$classes = $hints['Root']['disallowedChildren'];
 		$this->assertContains('ErrorPage', $classes);
 		$this->assertContains('SiteTreeSubsitesTest_ClassA', $classes);
-		$this->assertContains('SiteTreeSubsitesTest_ClassB', $classes);
+		$this->assertNotContains('SiteTreeSubsitesTest_ClassB', $classes);
+
+		Subsite::changeSubsite($s2);
+		$hints = Convert::json2array($cmsmain->SiteTreeHints());
+		$classes = $hints['Root']['disallowedChildren'];
+		$this->assertNotContains('ErrorPage', $classes);
+		$this->assertNotContains('SiteTreeSubsitesTest_ClassA', $classes);
+		$this->assertNotContains('SiteTreeSubsitesTest_ClassB', $classes);
 	}
 	
 }


### PR DESCRIPTION
See http://www.silverstripe.org/software/download/security-releases/ss-2015-008-sitetree-creation-permission-vulnerability

Logged out users can never create pages (fixed in cms)

CMSMain controls pages creatable at the root using SiteTreeHints, as the PageTypes no longer assumes knowledge of the ability to create pages.