### PR TITLE
SubsitesVirtualPage icon disapears in CMS

### DIFF
--- a/css/LeftAndMain_Subsites.css
+++ b/css/LeftAndMain_Subsites.css
@@ -82,7 +82,7 @@ body.SubsiteAdmin .right form #URL .fieldgroup * {
 	font-size: 11px;
 }
 
-.cms-add-form #PageType li .class-SubsitesVirtualPage, .class-SubsitesVirtualPage a .jstree-pageicon {
+.cms-add-form #PageType li .class-SubsitesVirtualPage {
 	background-position: 0 -32px !important;
 }
 


### PR DESCRIPTION
The SubsitesVirtualPage icon is hidden in the CMS when using the subsite module and CWP