### PR TITLE
Selection of Subsite Virtual Page showing wrong site tree

### DIFF
--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -217,7 +217,11 @@ class LeftAndMainSubsites extends Extension {
 			// Update current subsite in session
 			Subsite::changeSubsite($_GET['SubsiteID']);
 
-			//Redirect to clear the current page
+			if ($this->owner->canView(Member::currentUser())) {
+				//Redirect to clear the current page
+				return $this->owner->redirect($this->owner->Link());
+			}
+			//Redirect to the default CMS section
 			return $this->owner->redirect('admin/');
 		}
 
@@ -230,7 +234,11 @@ class LeftAndMainSubsites extends Extension {
 				// Update current subsite in session
 				Subsite::changeSubsite($record->SubsiteID);
 
-				//Redirect to clear the current page
+				if ($this->owner->canView(Member::currentUser())) {
+					//Redirect to clear the current page
+					return $this->owner->redirect($this->owner->Link());
+				}
+				//Redirect to the default CMS section
 				return $this->owner->redirect('admin/');
 			}
 

--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -207,21 +207,6 @@ class LeftAndMainSubsites extends Extension {
 
 		// FIRST, check if we need to change subsites due to the URL.
 
-		// Automatically redirect the session to appropriate subsite when requesting a record.
-		// This is needed to properly initialise the session in situations where someone opens the CMS via a link.
-		$record = $this->owner->currentPage();
-		if($record && isset($record->SubsiteID) && is_numeric($record->SubsiteID)) {
-
-			if ($this->shouldChangeSubsite($this->owner->class, $record->SubsiteID, Subsite::currentSubsiteID())) {
-				// Update current subsite in session
-				Subsite::changeSubsite($record->SubsiteID);
-
-				//Redirect to clear the current page
-				return $this->owner->redirect('admin/');
-			}
-
-		}
-
 		// Catch forced subsite changes that need to cause CMS reloads.
 		if(isset($_GET['SubsiteID'])) {
 			// Clear current page when subsite changes (or is set for the first time)
@@ -234,6 +219,21 @@ class LeftAndMainSubsites extends Extension {
 
 			//Redirect to clear the current page
 			return $this->owner->redirect('admin/');
+		}
+
+		// Automatically redirect the session to appropriate subsite when requesting a record.
+		// This is needed to properly initialise the session in situations where someone opens the CMS via a link.
+		$record = $this->owner->currentPage();
+		if($record && isset($record->SubsiteID) && is_numeric($record->SubsiteID) && isset($this->owner->urlParams['ID'])) {
+
+			if ($this->shouldChangeSubsite($this->owner->class, $record->SubsiteID, Subsite::currentSubsiteID())) {
+				// Update current subsite in session
+				Subsite::changeSubsite($record->SubsiteID);
+
+				//Redirect to clear the current page
+				return $this->owner->redirect('admin/');
+			}
+
 		}
 
 		// SECOND, check if we need to change subsites due to lack of permissions.

--- a/code/extensions/LeftAndMainSubsites.php
+++ b/code/extensions/LeftAndMainSubsites.php
@@ -217,12 +217,10 @@ class LeftAndMainSubsites extends Extension {
 			// Update current subsite in session
 			Subsite::changeSubsite($_GET['SubsiteID']);
 
-			if ($this->owner->canView(Member::currentUser())) {
-				//Redirect to clear the current page
-				return $this->owner->redirect($this->owner->Link());
+			if (!$this->owner->canView(Member::currentUser())) {
+				//Redirect to the default CMS section
+				return $this->owner->redirect('admin/');
 			}
-			//Redirect to the default CMS section
-			return $this->owner->redirect('admin/');
 		}
 
 		// Automatically redirect the session to appropriate subsite when requesting a record.
@@ -234,12 +232,10 @@ class LeftAndMainSubsites extends Extension {
 				// Update current subsite in session
 				Subsite::changeSubsite($record->SubsiteID);
 
-				if ($this->owner->canView(Member::currentUser())) {
-					//Redirect to clear the current page
-					return $this->owner->redirect($this->owner->Link());
+				if (!$this->owner->canView(Member::currentUser())) {
+					//Redirect to the default CMS section
+					return $this->owner->redirect('admin/');
 				}
-				//Redirect to the default CMS section
-				return $this->owner->redirect('admin/');
 			}
 
 		}

--- a/tests/SiteTreeSubsitesTest.php
+++ b/tests/SiteTreeSubsitesTest.php
@@ -8,6 +8,10 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 		'SiteTreeSubsitesTest_ClassA',
 		'SiteTreeSubsitesTest_ClassB'
 	);
+
+	protected $illegalExtensions = array(
+		'SiteTree' => array('Translatable')
+	);
 	
 	function testPagesInDifferentSubsitesCanShareURLSegment() {
 		$subsiteMain = $this->objFromFixture('Subsite', 'main');
@@ -129,7 +133,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 	}
 	
 	function testPageTypesBlacklistInClassDropdown() {
-		Session::set("loggedInAs", null);
+		$this->logInWithPermission('CMS_ACCESS_CMSMain');
 		
 		$s1 = $this->objFromFixture('Subsite','domaintest1');
 		$s2 = $this->objFromFixture('Subsite','domaintest2');
@@ -164,7 +168,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 	}
 	
 	function testPageTypesBlacklistInCMSMain() {
-		Session::set("loggedInAs", null);
+		$this->logInWithPermission('CMS_ACCESS_CMSMain');
 		
 		$cmsmain = new CMSMain();
 		
@@ -175,16 +179,18 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest {
 		$s1->write();
 
 		Subsite::changeSubsite($s1);
-		$classes = $cmsmain->PageTypes()->column('ClassName');
-		$this->assertNotContains('ErrorPage', $classes);
-		$this->assertNotContains('SiteTreeSubsitesTest_ClassA', $classes);
-		$this->assertContains('SiteTreeSubsitesTest_ClassB', $classes);
-
-		Subsite::changeSubsite($s2);
-		$classes = $cmsmain->PageTypes()->column("ClassName");
+		$hints = Convert::json2array($cmsmain->SiteTreeHints());
+		$classes = $hints['Root']['disallowedChildren'];
 		$this->assertContains('ErrorPage', $classes);
 		$this->assertContains('SiteTreeSubsitesTest_ClassA', $classes);
-		$this->assertContains('SiteTreeSubsitesTest_ClassB', $classes);
+		$this->assertNotContains('SiteTreeSubsitesTest_ClassB', $classes);
+
+		Subsite::changeSubsite($s2);
+		$hints = Convert::json2array($cmsmain->SiteTreeHints());
+		$classes = $hints['Root']['disallowedChildren'];
+		$this->assertNotContains('ErrorPage', $classes);
+		$this->assertNotContains('SiteTreeSubsitesTest_ClassA', $classes);
+		$this->assertNotContains('SiteTreeSubsitesTest_ClassB', $classes);
 	}
 	
 }


### PR DESCRIPTION
The dropdown field for the Subsite Virtual page do not show the selected subtsite site tree, instead it always show the current subsite tree.