### PR TITLE
Add sticky nav toggle button

### DIFF
--- a/templates/LeftAndMain_Menu.ss
+++ b/templates/LeftAndMain_Menu.ss
@@ -37,6 +37,8 @@
 	</div>
 		
 	<div class="cms-panel-toggle south">
+		<button class="sticky-toggle" type="button" title="Sticky nav">Sticky nav</button>
+		<span class="sticky-status-indicator">auto</span>
 		<a class="toggle-expand" href="#"><span>&raquo;</span></a>
 		<a class="toggle-collapse" href="#"><span>&laquo;</span></a>
 	</div>


### PR DESCRIPTION
Added the button down the bottom of the main CMS menu to toggle the 'sticky' state of the menu