### PR TITLE
BUG Fix menu compatibility with framework 4.x

### DIFF
--- a/templates/LeftAndMain_Menu.ss
+++ b/templates/LeftAndMain_Menu.ss
@@ -6,12 +6,12 @@
 			</a>
 			<span><% if $SiteConfig %>$SiteConfig.Title<% else %>$ApplicationName<% end_if %></span>
 		</div>
-	
+
 		<div class="cms-login-status">
-			<a href="Security/logout" class="logout-link" title="<% _t('LeftAndMain_Menu.LOGOUT','Log out') %>"><% _t('LeftAndMain_Menu.LOGOUT','Log out') %></a>
+			<a href="$LogoutURL" class="logout-link font-icon-logout" title="<%t LeftAndMain_Menu_ss.LOGOUT 'Log out' %>"></a>
 			<% with $CurrentMember %>
 				<span>
-					<% _t('LeftAndMain_Menu.Hello','Hi') %>
+					<%t LeftAndMain_Menu_ss.Hello 'Hi' %>
 					<a href="{$AbsoluteBaseURL}admin/myprofile" class="profile-link">
 						<% if $FirstName && $Surname %>$FirstName $Surname<% else_if $FirstName %>$FirstName<% else %>$Email<% end_if %>
 					</a>


### PR DESCRIPTION
Synchronises this module with the upstream framework template.

I've also created https://github.com/silverstripe/silverstripe-framework/pull/4795 to help minimise the impact of these kinds of issues in future, but neither depends on the other. (you can merge one or the other safely without regression).