### PR TITLE
Update templates for 3.3 compatibility

### DIFF
--- a/templates/LeftAndMain_Menu.ss
+++ b/templates/LeftAndMain_Menu.ss
@@ -8,10 +8,10 @@
 		</div>
 	
 		<div class="cms-login-status">
-			<a href="Security/logout" class="logout-link" title="<% _t('LeftAndMain_Menu.LOGOUT','Log out') %>"><% _t('LeftAndMain_Menu.LOGOUT','Log out') %></a>
+			<a href="$LogoutURL" class="logout-link font-icon-logout" title="<%t LeftAndMain_Menu_ss.LOGOUT 'Log out' %>"></a>
 			<% with $CurrentMember %>
 				<span>
-					<% _t('LeftAndMain_Menu.Hello','Hi') %>
+					<%t LeftAndMain_Menu_ss.Hello 'Hi' %>
 					<a href="{$AbsoluteBaseURL}admin/myprofile" class="profile-link">
 						<% if $FirstName && $Surname %>$FirstName $Surname<% else_if $FirstName %>$FirstName<% else %>$Email<% end_if %>
 					</a>


### PR DESCRIPTION
This fixes issues in the menu which cause the logout icon to appear incorrectly.

I've tested that this works in 3.2 as well.