### PR TITLE
Fix error when dataQuery is a null object

### DIFF
--- a/code/extensions/SiteTreeSubsites.php
+++ b/code/extensions/SiteTreeSubsites.php
@@ -33,7 +33,8 @@ class SiteTreeSubsites extends DataExtension
         if (Subsite::$disable_subsite_filter) {
             return;
         }
-        if ($dataQuery->getQueryParam('Subsite.filter') === false) {
+        
+        if ($dataQuery && $dataQuery->getQueryParam('Subsite.filter') === false) {
             return;
         }
         


### PR DESCRIPTION
Add additional check on dataQuery to prevent the error message: 'attempting to call a function on a non-object' in certain cases where $dataQuery variable is null.