### PR TITLE
BUG Fix issue with urlsegment being renamed in subsites

### DIFF
--- a/code/model/Subsite.php
+++ b/code/model/Subsite.php
@@ -9,8 +9,8 @@ class Subsite extends DataObject
 {
     /**
      * @var $use_session_subsiteid Boolean Set to TRUE when using the CMS and FALSE
-     * when browsing the frontend of a website. 
-     * 
+     * when browsing the frontend of a website.
+     *
      * @todo Remove flag once the Subsite CMS works without session state,
      * similarly to the Translatable module.
      */
@@ -21,7 +21,7 @@ class Subsite extends DataObject
      * to limit DataObject::get*() calls to a specific subsite. Useful for debugging.
      */
     public static $disable_subsite_filter = false;
-    
+
     /**
      * Allows you to force a specific subsite ID, or comma separated list of IDs.
      * Only works for reading. An object cannot be written to more than 1 subsite.
@@ -33,10 +33,10 @@ class Subsite extends DataObject
      * @var boolean
      */
     public static $write_hostmap = true;
-    
+
     /**
      * Memory cache of accessible sites
-     * 
+     *
      * @array
      */
     private static $_cache_accessible_sites = array();
@@ -54,7 +54,7 @@ class Subsite extends DataObject
      * are listed.
      */
     private static $allowed_themes = array();
-    
+
     /**
      * @var Boolean If set to TRUE, don't assume 'www.example.com' and 'example.com' are the same.
      * Doesn't affect wildcard matching, so '*.example.com' will match 'www.example.com' (but not 'example.com')
@@ -69,14 +69,14 @@ class Subsite extends DataObject
 
     /**
      * Set allowed themes
-     * 
+     *
      * @param array $themes - Numeric array of all themes which are allowed to be selected for all subsites.
      */
     public static function set_allowed_themes($themes)
     {
         self::$allowed_themes = $themes;
     }
-    
+
     /**
      * Gets the subsite currently set in the session.
      *
@@ -99,7 +99,6 @@ class Subsite extends DataObject
      *
      * @todo Pass $request object from controller so we don't have to rely on $_GET
      *
-     * @param boolean $cache
      * @return int ID of the current subsite instance
      */
     public static function currentSubsiteID()
@@ -118,7 +117,7 @@ class Subsite extends DataObject
 
         return (int)$id;
     }
-    
+
     /**
      * Switch to another subsite through storing the subsite identifier in the current PHP session.
      * Only takes effect when {@link Subsite::$use_session_subsiteid} is set to TRUE.
@@ -151,13 +150,13 @@ class Subsite extends DataObject
 
         Permission::flush_permission_cache();
     }
-    
+
     /**
      * Get a matching subsite for the given host, or for the current HTTP_HOST.
      * Supports "fuzzy" matching of domains by placing an asterisk at the start of end of the string,
      * for example matching all subdomains on *.example.com with one subsite,
      * and all subdomains on *.example.org on another.
-     * 
+     *
      * @param $host The host to find the subsite for.  If not specified, $_SERVER['HTTP_HOST'] is used.
      * @return int Subsite ID
      */
@@ -215,7 +214,7 @@ class Subsite extends DataObject
     }
 
     /**
-     * 
+     *
      * @param string $className
      * @param string $filter
      * @param string $sort
@@ -237,7 +236,7 @@ class Subsite extends DataObject
     {
         self::$disable_subsite_filter = $disabled;
     }
-    
+
     /**
      * Flush caches on database reset
      */
@@ -246,7 +245,7 @@ class Subsite extends DataObject
         self::$_cache_accessible_sites = array();
         self::$_cache_subsite_for_domain = array();
     }
-    
+
     /**
      * Return all subsites, regardless of permissions (augmented with main site).
      *
@@ -333,13 +332,13 @@ class Subsite extends DataObject
             $member = DataObject::get_by_id('Member', $member);
         }
 
-        // Rationalise permCode argument 
+        // Rationalise permCode argument
         if (is_array($permCode)) {
             $SQL_codes = "'" . implode("', '", Convert::raw2sql($permCode)) . "'";
         } else {
             $SQL_codes = "'" . Convert::raw2sql($permCode) . "'";
         }
-        
+
         // Cache handling
         $cacheKey = $SQL_codes . '-' . $member->ID . '-' . $includeMainSite . '-' . $mainSiteTitle;
         if (isset(self::$_cache_accessible_sites[$cacheKey])) {
@@ -386,19 +385,19 @@ class Subsite extends DataObject
             }
             if (self::hasMainSitePermission($member, $permCode)) {
                 $subsites=$subsites->toArray();
-                
+
                 $mainSite = new Subsite();
                 $mainSite->Title = $mainSiteTitle;
                 array_unshift($subsites, $mainSite);
                 $subsites=ArrayList::create($subsites);
             }
         }
-        
+
         self::$_cache_accessible_sites[$cacheKey] = $subsites;
 
         return $subsites;
     }
-    
+
     /**
      * Write a host->domain map to subsites/host-map.php
      *
@@ -412,14 +411,14 @@ class Subsite extends DataObject
         if (!self::$write_hostmap) {
             return;
         }
-        
+
         if (!$file) {
             $file = Director::baseFolder().'/subsites/host-map.php';
         }
         $hostmap = array();
-        
+
         $subsites = DataObject::get('Subsite');
-        
+
         if ($subsites) {
             foreach ($subsites as $subsite) {
                 $domains = $subsite->Domains();
@@ -437,7 +436,7 @@ class Subsite extends DataObject
                 }
             }
         }
-        
+
         $data = "<?php \n";
         $data .= "// Generated by Subsite::writeHostMap() on " . date('d/M/y') . "\n";
         $data .= '$subsiteHostmap = ' . var_export($hostmap, true) . ';';
@@ -446,16 +445,16 @@ class Subsite extends DataObject
             file_put_contents($file, $data);
         }
     }
-    
+
     /**
      * Checks if a member can be granted certain permissions, regardless of the subsite context.
      * Similar logic to {@link Permission::checkMember()}, but only returns TRUE
      * if the member is part of a group with the "AccessAllSubsites" flag set.
      * If more than one permission is passed to the method, at least one of them must
      * be granted for if to return TRUE.
-     * 
+     *
      * @todo Allow permission inheritance through group hierarchy.
-     * 
+     *
      * @param Member Member to check against. Defaults to currently logged in member
      * @param Array Permission code strings. Defaults to "ADMIN".
      * @return boolean
@@ -473,7 +472,7 @@ class Subsite extends DataObject
         if (!$member) {
             return false;
         }
-        
+
         if (!in_array("ADMIN", $permissionCodes)) {
             $permissionCodes[] = "ADMIN";
         }
@@ -481,7 +480,7 @@ class Subsite extends DataObject
         $SQLa_perm = Convert::raw2sql($permissionCodes);
         $SQL_perms = join("','", $SQLa_perm);
         $memberID = (int)$member->ID;
-        
+
         // Count this user's groups which can access the main site
         $groupCount = DB::query("
 			SELECT COUNT(\"Permission\".\"ID\")
@@ -508,7 +507,7 @@ class Subsite extends DataObject
         // There has to be at least one that allows access.
         return ($groupCount + $roleCount > 0);
     }
-    
+
     /**
      *
      * @var array
@@ -523,7 +522,7 @@ class Subsite extends DataObject
         // Used to hide unfinished/private subsites from public view.
         // If unset, will default to true
         'IsPublic' => 'Boolean',
-        
+
         // Comma-separated list of disallowed page types
         'PageTypeBlacklist' => 'Text',
     );
@@ -535,7 +534,7 @@ class Subsite extends DataObject
     private static $has_many = array(
         'Domains' => 'SubsiteDomain',
     );
-    
+
     /**
      *
      * @var array
@@ -561,13 +560,13 @@ class Subsite extends DataObject
         'Domains.Domain',
         'IsPublic',
     );
-    
+
     /**
      *
      * @var string
      */
     private static $default_sort = "\"Title\" ASC";
-    
+
     /**
      * @todo Possible security issue, don't grant edit permissions to everybody.
      * @return boolean
@@ -579,7 +578,7 @@ class Subsite extends DataObject
 
     /**
      * Show the configuration fields for each subsite
-     * 
+     *
      * @return FieldList
      */
     public function getCMSFields()
@@ -597,13 +596,13 @@ class Subsite extends DataObject
                 '<p>'._t('Subsite.DOMAINSAVEFIRST', 'You can only add domains after saving for the first time').'</p>'
             );
         }
-            
+
         $languageSelector = new DropdownField(
             'Language',
             $this->fieldLabel('Language'),
             i18n::get_common_locales()
         );
-        
+
         $pageTypeMap = array();
         $pageTypes = SiteTree::page_type_classes();
         foreach ($pageTypes as $pageType) {
@@ -618,7 +617,7 @@ class Subsite extends DataObject
                     _t('Subsite.TabTitleConfig', 'Configuration'),
                     new HeaderField($this->getClassName() . ' configuration', 2),
                     new TextField('Title', $this->fieldLabel('Title'), $this->Title),
-                    
+
                     new HeaderField(
                         _t('Subsite.DomainsHeadline', "Domains for this subsite")
                     ),
@@ -629,8 +628,8 @@ class Subsite extends DataObject
                     new CheckboxField('IsPublic', $this->fieldLabel('IsPublic'), $this->IsPublic),
 
                     new DropdownField('Theme', $this->fieldLabel('Theme'), $this->allowedThemes(), $this->Theme),
-                    
-                    
+
+
                     new LiteralField(
                         'PageTypeBlacklistToggle',
                         sprintf(
@@ -654,9 +653,9 @@ class Subsite extends DataObject
         $this->extend('updateCMSFields', $fields);
         return $fields;
     }
-    
+
     /**
-     * 
+     *
      * @param boolean $includerelations
      * @return array
      */
@@ -677,7 +676,7 @@ class Subsite extends DataObject
     }
 
     /**
-     * 
+     *
      * @return array
      */
     public function summaryFields()
@@ -688,10 +687,10 @@ class Subsite extends DataObject
             'IsPublic' => _t('Subsite.IsPublicHeaderField', 'Active subsite'),
         );
     }
-    
+
     /**
      * Return the themes that can be used with this subsite, as an array of themecode => description
-     * 
+     *
      * @return array
      */
     public function allowedThemes()
@@ -727,7 +726,7 @@ class Subsite extends DataObject
     }
 
     /**
-     * 
+     *
      * @return ValidationResult
      */
     public function validate()
@@ -749,11 +748,11 @@ class Subsite extends DataObject
         Subsite::writeHostMap();
         parent::onAfterWrite();
     }
-    
+
     /**
      * Return the primary domain of this site. Tries to "normalize" the domain name,
      * by replacing potential wildcards.
-     * 
+     *
      * @return string The full domain name of this subsite (without protocol prefix)
      */
     public function domain()
@@ -780,9 +779,9 @@ class Subsite extends DataObject
             ->sort('"IsPrimary" DESC')
             ->first();
     }
-    
+
     /**
-     * 
+     *
      * @return string - The full domain name of this subsite (without protocol prefix)
      */
     public function getPrimaryDomain()
@@ -792,7 +791,7 @@ class Subsite extends DataObject
 
     /**
      * Get the absolute URL for this subsite
-     * @return string 
+     * @return string
      */
     public function absoluteBaseURL()
     {
@@ -816,8 +815,8 @@ class Subsite extends DataObject
 
     /**
      * Javascript admin action to duplicate this subsite
-     * 
-     * @return string - javascript 
+     *
+     * @return string - javascript
      */
     public function adminDuplicate()
     {
@@ -827,7 +826,7 @@ class Subsite extends DataObject
             'Created a copy of {title}',
             array('title' => Convert::raw2js($this->Title))
         );
-        
+
         return <<<JS
 			statusMessage($message, 'good');
 			$('Form_EditForm').loadURLFromServer('admin/subsites/show/$newItem->ID');
@@ -843,7 +842,7 @@ JS;
     }
 
     /**
-     * 
+     *
      * @param array $permissionCodes
      * @return DataList
      */

--- a/tests/BaseSubsiteTest.php
+++ b/tests/BaseSubsiteTest.php
@@ -6,6 +6,7 @@ class BaseSubsiteTest extends SapphireTest
         parent::setUp();
 
         Subsite::$use_session_subsiteid = true;
+		Subsite::$force_subsite = null;
     }
 
     /**

--- a/tests/SiteTreeSubsitesTest.php
+++ b/tests/SiteTreeSubsitesTest.php
@@ -3,7 +3,7 @@
 class SiteTreeSubsitesTest extends BaseSubsiteTest
 {
     public static $fixture_file = 'subsites/tests/SubsiteTest.yml';
-    
+
     protected $extraDataObjects = array(
         'SiteTreeSubsitesTest_ClassA',
         'SiteTreeSubsitesTest_ClassB'
@@ -12,38 +12,38 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
     protected $illegalExtensions = array(
         'SiteTree' => array('Translatable')
     );
-    
+
     public function testPagesInDifferentSubsitesCanShareURLSegment()
     {
         $subsiteMain = $this->objFromFixture('Subsite', 'main');
         $subsite1 = $this->objFromFixture('Subsite', 'subsite1');
-        
+
         $pageMain = new SiteTree();
         $pageMain->URLSegment = 'testpage';
         $pageMain->write();
         $pageMain->publish('Stage', 'Live');
-        
+
         $pageMainOther = new SiteTree();
         $pageMainOther->URLSegment = 'testpage';
         $pageMainOther->write();
         $pageMainOther->publish('Stage', 'Live');
-        
+
         $this->assertNotEquals($pageMain->URLSegment, $pageMainOther->URLSegment,
             'Pages in same subsite cant share the same URL'
         );
-    
+
         Subsite::changeSubsite($subsite1->ID);
-    
+
         $pageSubsite1 = new SiteTree();
         $pageSubsite1->URLSegment = 'testpage';
         $pageSubsite1->write();
         $pageSubsite1->publish('Stage', 'Live');
-        
+
         $this->assertEquals($pageMain->URLSegment, $pageSubsite1->URLSegment,
             'Pages in different subsites can share the same URL'
         );
     }
-    
+
     public function testBasicSanity()
     {
         $this->assertTrue(singleton('SiteTree')->getSiteConfig() instanceof SiteConfig);
@@ -52,19 +52,19 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         $this->assertTrue(singleton('SubsitesVirtualPage')->getCMSFields() instanceof FieldList);
         $this->assertTrue(is_array(singleton('SiteTreeSubsites')->extraStatics()));
     }
-    
+
     public function testErrorPageLocations()
     {
         $subsite1 = $this->objFromFixture('Subsite', 'domaintest1');
-        
+
         Subsite::changeSubsite($subsite1->ID);
         $path = ErrorPage::get_filepath_for_errorcode(500);
-        
+
         $static_path = Config::inst()->get('ErrorPage', 'static_filepath');
         $expected_path = $static_path . '/error-500-'.$subsite1->domain().'.html';
         $this->assertEquals($expected_path, $path);
     }
-    
+
     public function testCanEditSiteTree()
     {
         $admin = $this->objFromFixture('Member', 'admin');
@@ -75,29 +75,29 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         $subsite2page = $this->objFromFixture('Page', 'subsite2_home');
         $subsite1 = $this->objFromFixture('Subsite', 'subsite1');
         $subsite2 = $this->objFromFixture('Subsite', 'subsite2');
-    
+
         // Cant pass member as arguments to canEdit() because of GroupSubsites
         Session::set("loggedInAs", $admin->ID);
         $this->assertTrue(
             (bool)$subsite1page->canEdit(),
             'Administrators can edit all subsites'
         );
-    
+
         // @todo: Workaround because GroupSubsites->augmentSQL() is relying on session state
         Subsite::changeSubsite($subsite1);
-        
+
         Session::set("loggedInAs", $subsite1member->ID);
         $this->assertTrue(
             (bool)$subsite1page->canEdit(),
             'Members can edit pages on a subsite if they are in a group belonging to this subsite'
         );
-    
+
         Session::set("loggedInAs", $subsite2member->ID);
         $this->assertFalse(
             (bool)$subsite1page->canEdit(),
             'Members cant edit pages on a subsite if they are not in a group belonging to this subsite'
         );
-        
+
         // @todo: Workaround because GroupSubsites->augmentSQL() is relying on session state
         Subsite::changeSubsite(0);
         $this->assertFalse(
@@ -105,7 +105,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
             'Members cant edit pages on the main site if they are not in a group allowing this'
         );
     }
-    
+
     /**
      * Similar to {@link SubsitesVirtualPageTest->testSubsiteVirtualPageCanHaveSameUrlsegmentAsOtherSubsite()}.
      */
@@ -114,7 +114,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         // Set up a couple of pages with the same URL on different subsites
         $s1 = $this->objFromFixture('Subsite', 'domaintest1');
         $s2 = $this->objFromFixture('Subsite', 'domaintest2');
-        
+
         $p1 = new SiteTree();
         $p1->Title = $p1->URLSegment = "test-page";
         $p1->SubsiteID = $s1->ID;
@@ -128,7 +128,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         // Check that the URLs weren't modified in our set-up
         $this->assertEquals($p1->URLSegment, 'test-page');
         $this->assertEquals($p2->URLSegment, 'test-page');
-        
+
         // Check that if we switch between the different subsites, we receive the correct pages
         Subsite::changeSubsite($s1);
         $this->assertEquals($p1->ID, SiteTree::get_by_link('test-page')->ID);
@@ -136,22 +136,22 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         Subsite::changeSubsite($s2);
         $this->assertEquals($p2->ID, SiteTree::get_by_link('test-page')->ID);
     }
-    
+
     public function testPageTypesBlacklistInClassDropdown()
     {
         $editor = $this->objFromFixture('Member', 'editor');
         Session::set("loggedInAs", $editor->ID);
-        
+
         $s1 = $this->objFromFixture('Subsite', 'domaintest1');
         $s2 = $this->objFromFixture('Subsite', 'domaintest2');
         $page = singleton('SiteTree');
-        
+
         $s1->PageTypeBlacklist = 'SiteTreeSubsitesTest_ClassA,ErrorPage';
         $s1->write();
-        
+
         Subsite::changeSubsite($s1);
         $settingsFields = $page->getSettingsFields()->dataFieldByName('ClassName')->getSource();
-        
+
         $this->assertArrayNotHasKey('ErrorPage',
             $settingsFields
         );
@@ -174,17 +174,17 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
             $settingsFields
         );
     }
-    
+
     public function testPageTypesBlacklistInCMSMain()
     {
         $editor = $this->objFromFixture('Member', 'editor');
         Session::set("loggedInAs", $editor->ID);
-        
+
         $cmsmain = new CMSMain();
-        
+
         $s1 = $this->objFromFixture('Subsite', 'domaintest1');
         $s2 = $this->objFromFixture('Subsite', 'domaintest2');
-        
+
         $s1->PageTypeBlacklist = 'SiteTreeSubsitesTest_ClassA,ErrorPage';
         $s1->write();
 
@@ -202,6 +202,65 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         $this->assertNotContains('SiteTreeSubsitesTest_ClassA', $classes);
         $this->assertNotContains('SiteTreeSubsitesTest_ClassB', $classes);
     }
+
+	/**
+	 * Tests that url segments between subsites don't conflict, but do conflict within them
+	 */
+	public function testValidateURLSegment() {
+		$this->logInWithPermission('ADMIN');
+		// Saving existing page in the same subsite doesn't change urls
+		$mainHome = $this->objFromFixture('Page', 'home');
+		$mainSubsiteID = $this->idFromFixture('Subsite', 'main');
+		Subsite::changeSubsite($mainSubsiteID);
+		$mainHome->Content = '<p>Some new content</p>';
+		$mainHome->write();
+		$this->assertEquals('home', $mainHome->URLSegment);
+		$mainHome->doPublish();
+		$mainHomeLive = Versioned::get_one_by_stage('Page', 'Live', sprintf('"SiteTree"."ID" = \'%d\'', $mainHome->ID));
+		$this->assertEquals('home', $mainHomeLive->URLSegment);
+
+		// Saving existing page in another subsite doesn't change urls
+		Subsite::changeSubsite($mainSubsiteID);
+		$subsite1Home = $this->objFromFixture('Page', 'subsite1_home');
+		$subsite1Home->Content = '<p>In subsite 1</p>';
+		$subsite1Home->write();
+		$this->assertEquals('home', $subsite1Home->URLSegment);
+		$subsite1Home->doPublish();
+		$subsite1HomeLive = Versioned::get_one_by_stage('Page', 'Live', sprintf('"SiteTree"."ID" = \'%d\'', $subsite1Home->ID));
+		$this->assertEquals('home', $subsite1HomeLive->URLSegment);
+
+		// Creating a new page in a subsite doesn't conflict with urls in other subsites
+        $subsite1ID = $this->idFromFixture('Subsite', 'subsite1');
+		Subsite::changeSubsite($subsite1ID);
+		$subsite1NewPage = new Page();
+		$subsite1NewPage->SubsiteID = $subsite1ID;
+		$subsite1NewPage->Title = 'Important Page (Subsite 1)';
+		$subsite1NewPage->URLSegment = 'important-page'; // Also exists in main subsite
+		$subsite1NewPage->write();
+		$this->assertEquals('important-page', $subsite1NewPage->URLSegment);
+		$subsite1NewPage->doPublish();
+		$subsite1NewPageLive = Versioned::get_one_by_stage('Page', 'Live', sprintf('"SiteTree"."ID" = \'%d\'', $subsite1NewPage->ID));
+		$this->assertEquals('important-page', $subsite1NewPageLive->URLSegment);
+
+		// Creating a new page in a subsite DOES conflict with urls in the same subsite
+		$subsite1NewPage2 = new Page();
+		$subsite1NewPage2->SubsiteID = $subsite1ID;
+		$subsite1NewPage2->Title = 'Important Page (Subsite 1)';
+		$subsite1NewPage2->URLSegment = 'important-page'; // Also exists in main subsite
+		$subsite1NewPage2->write();
+		$this->assertEquals('important-page-2', $subsite1NewPage2->URLSegment);
+		$subsite1NewPage2->doPublish();
+		$subsite1NewPage2Live = Versioned::get_one_by_stage('Page', 'Live', sprintf('"SiteTree"."ID" = \'%d\'', $subsite1NewPage2->ID));
+		$this->assertEquals('important-page-2', $subsite1NewPage2Live->URLSegment);
+
+		// Original page is left un-modified
+		$mainSubsiteImportantPageID = $this->idFromFixture('Page', 'importantpage');
+		$mainSubsiteImportantPage = Page::get()->byID($mainSubsiteImportantPageID);
+		$this->assertEquals('important-page', $mainSubsiteImportantPage->URLSegment);
+		$mainSubsiteImportantPage->Content = '<p>New Important Page Content</p>';
+		$mainSubsiteImportantPage->write();
+		$this->assertEquals('important-page', $mainSubsiteImportantPage->URLSegment);
+	}
 }
 
 class SiteTreeSubsitesTest_ClassA extends SiteTree implements TestOnly

--- a/tests/SubsiteTest.yml
+++ b/tests/SubsiteTest.yml
@@ -64,40 +64,52 @@ Page:
   mainSubsitePage:
     Title: MainSubsitePage
     SubsiteID: 0
+    URLSegment: mainsubsitepage
   home:
     Title: Home
     SubsiteID: =>Subsite.main
+    URLSegment: home
   about:
     Title: About
     SubsiteID: =>Subsite.main
+    URLSegment: about
   linky:
      Title: Linky
      SubsiteID: =>Subsite.main
+     URLSegment: linky
   staff:
     Title: Staff
     ParentID: =>Page.about
     SubsiteID: =>Subsite.main
+    URLSegment: staff
   contact:
     Title: Contact Us
     SubsiteID: =>Subsite.main
+    URLSegment: contact-us
   importantpage:
     Title: Important Page
     SubsiteID: =>Subsite.main
+    URLSegment: important-page
   subsite1_home:
     Title: Home (Subsite 1)
     SubsiteID: =>Subsite.subsite1
+    URLSegment: home
   subsite1_contactus:
     Title: Contact Us (Subsite 1)
     SubsiteID: =>Subsite.subsite1
+    URLSegment: contact-us
   subsite1_staff:
     Title: Staff
     SubsiteID: =>Subsite.subsite1
+    URLSegment: staff
   subsite2_home:
     Title: Home (Subsite 2)
     SubsiteID: =>Subsite.subsite2
+    URLSegment: home
   subsite2_contactus:
     Title: Contact Us (Subsite 2)
     SubsiteID: =>Subsite.subsite2
+    URLSegment: contact-us
 
 PermissionRoleCode:
   roleCode1:


### PR DESCRIPTION
With this fix in place, validateURLSegment() will no longer check for conflicts against pages that belong to other subsites.

I've also removed the custom logic from SubsiteVirtualPage: It didn't work properly, and the substituted logic should work better. :) This is covered by existing tests.

Fixes #193 and #53 

The code in this module is super-due for a rewrite soon.