### PR TITLE
BUG Prevent SubsiteXHRController failing if there are no subsites available

### DIFF
--- a/code/SubsiteXHRController.php
+++ b/code/SubsiteXHRController.php
@@ -22,13 +22,15 @@ class SubsiteXHRController extends LeftAndMain
     }
 
     /**
-     * Similar as above, but for the LeftAndMainSubsites - allow access if user allowed into the CMS at all.
+     * Allow access if user allowed into the CMS at all.
      */
     public function canAccess()
     {
-        if (Subsite::all_accessible_sites()->count()>0) {
-            return true;
-        }
+		// Allow if any cms access is available
+        return Permission::check(array(
+			'CMS_ACCESS', // Supported by 3.1.14 and up
+			'CMS_ACCESS_LeftAndMain'
+		));
     }
 
     public function getResponseNegotiator()

--- a/tests/SubsiteXHRControllerTest.php
+++ b/tests/SubsiteXHRControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Created by PhpStorm.
+ * User: dmooyman
+ * Date: 27/05/16
+ * Time: 3:10 PM
+ */
+class SubsiteXHRControllerTest extends FunctionalTest
+{
+	protected static $fixture_file = 'SubsiteTest.yml';
+
+	public function testCanView() {
+		// Test unauthenticated access
+		Session::clear('MemberID');
+		$result = $this->get('SubsiteXHRController', null, array(
+			'X-Pjax' => 'SubsiteList',
+			'X-Requested-With' => 'XMLHttpRequest'
+		));
+		$this->assertEquals(403, $result->getStatusCode());
+
+		// Login with NO permissions
+		$this->logInWithPermission('NOT_CMS_PERMISSION');
+		$result = $this->get('SubsiteXHRController', null, array(
+			'X-Pjax' => 'SubsiteList',
+			'X-Requested-With' => 'XMLHttpRequest'
+		));
+		$this->assertEquals(403, $result->getStatusCode());
+
+		// Test cms user
+		$this->logInWithPermission('CMS_ACCESS_CMSMain');
+		$result = $this->get('SubsiteXHRController', null, array(
+			'X-Pjax' => 'SubsiteList',
+			'X-Requested-With' => 'XMLHttpRequest'
+		));
+		$this->assertEquals(200, $result->getStatusCode());
+		$this->assertEquals('text/json', $result->getHeader('Content-Type'));
+		$body = $result->getBody();
+		$this->assertContains('Main site', $body);
+		$this->assertContains('Test 1', $body);
+		$this->assertContains('Test 2', $body);
+		$this->assertContains('Test 3', $body);
+	}
+}


### PR DESCRIPTION
Fixes #200

The problem is that, even if there are no subsites available, that doesn't mean you're not allowed to know there are no subsites. :)  This replaces the logic check with an actual permission check.

Jira ticket at https://silverstripe.atlassian.net/browse/CWP-697