### PR TITLE
Fix error when dataQuery is a null object

### DIFF
--- a/code/extensions/SiteTreeSubsites.php
+++ b/code/extensions/SiteTreeSubsites.php
@@ -33,7 +33,7 @@ class SiteTreeSubsites extends DataExtension
         if (Subsite::$disable_subsite_filter) {
             return;
         }
-        if ($dataQuery->getQueryParam('Subsite.filter') === false) {
+        if ($dataQuery && $dataQuery->getQueryParam('Subsite.filter') === false) {
             return;
         }
 


### PR DESCRIPTION
Credit to @mparkhill who fixed this originally, but never raised a pull request to get the fix back to the base module.