### PR TITLE
BUG Prevent translatable / subdirs interfering with test state

### DIFF
--- a/tests/FileSubsitesTest.php
+++ b/tests/FileSubsitesTest.php
@@ -13,9 +13,12 @@ class FileSubsitesTest extends BaseSubsiteTest
         'File' => array(
             'SecureFileExtension',
             'VersionedFileExtension'
-        )
+        ),
+		'SiteTree' => array(
+			'Translatable',
+		)
 	);
-    
+
     public function testTrivialFeatures()
     {
         $this->assertTrue(is_array(singleton('FileSubsites')->extraStatics()));
@@ -29,35 +32,35 @@ class FileSubsitesTest extends BaseSubsiteTest
         Subsite::changeSubsite(1);
         $this->assertEquals($file->cacheKeyComponent(), 'subsite-1');
     }
-    
+
     public function testWritingSubsiteID()
     {
         $this->objFromFixture('Member', 'admin')->logIn();
-        
+
         $subsite = $this->objFromFixture('Subsite', 'domaintest1');
         FileSubsites::$default_root_folders_global = true;
-        
+
         Subsite::changeSubsite(0);
         $file = new File();
         $file->write();
         $file->onAfterUpload();
         $this->assertEquals((int)$file->SubsiteID, 0);
-        
+
         Subsite::changeSubsite($subsite->ID);
         $this->assertTrue($file->canEdit());
-        
+
         $file = new File();
         $file->write();
         $this->assertEquals((int)$file->SubsiteID, 0);
         $this->assertTrue($file->canEdit());
-        
+
         FileSubsites::$default_root_folders_global = false;
-        
+
         Subsite::changeSubsite($subsite->ID);
         $file = new File();
         $file->write();
         $this->assertEquals($file->SubsiteID, $subsite->ID);
-        
+
         // Test inheriting from parent folder
         $folder = new Folder();
         $folder->write();

--- a/tests/SiteTreeSubsitesTest.php
+++ b/tests/SiteTreeSubsitesTest.php
@@ -176,6 +176,9 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
     }
 
 	public function testCopyToSubsite() {
+		// Remove baseurl if testing in subdir
+		Config::inst()->update('Director', 'alternate_base_url', '/');
+
 		/** @var Subsite $otherSubsite */
 		$otherSubsite = $this->objFromFixture('Subsite', 'subsite1');
 		$staffPage = $this->objFromFixture('Page', 'staff'); // nested page

--- a/tests/SubsitesVirtualPageTest.php
+++ b/tests/SubsitesVirtualPageTest.php
@@ -7,6 +7,10 @@ class SubsitesVirtualPageTest extends BaseSubsiteTest
         'subsites/tests/SubsitesVirtualPageTest.yml',
     );
 
+    protected $illegalExtensions = array(
+        'SiteTree' => array('Translatable')
+    );
+
     public function setUp()
     {
         parent::setUp();


### PR DESCRIPTION
Some environmental issues arise when testing in a non-root folder, or with the translatable module installed. This simply ensures that these don't interfere with subsites-specific tests.