### PR TITLE
Update SQL to explicitly use link table column

### DIFF
--- a/code/model/Subsite.php
+++ b/code/model/Subsite.php
@@ -461,7 +461,7 @@ JS;
 			INNER JOIN \"Group\" ON \"Group\".\"ID\" = \"Permission\".\"GroupID\" AND \"Group\".\"AccessAllSubsites\" = 1
 			INNER JOIN \"Group_Members\" ON \"Group_Members\".\"GroupID\" = \"Permission\".\"GroupID\"
 			WHERE \"Permission\".\"Code\" IN ('$SQL_perms')
-			AND \"MemberID\" = {$memberID}
+			AND \"Group_Members\".\"MemberID\" = {$memberID}
 		")->value();
 
 		// Count this user's groups which have a role that can access the main site
@@ -474,7 +474,7 @@ JS;
 			INNER JOIN \"PermissionRoleCode\" ON \"PermissionRole\".\"ID\"=\"PermissionRoleCode\".\"RoleID\"
 			WHERE \"PermissionRoleCode\".\"Code\" IN ('$SQL_perms')
 			AND \"Group\".\"AccessAllSubsites\" = 1
-			AND \"MemberID\" = {$memberID}
+			AND \"Group_Members\".\"MemberID\" = {$memberID}
 		")->value();
 
 		// There has to be at least one that allows access.


### PR DESCRIPTION
Explicitly use tablename in SQL to avoid column ambiguity.

Avoids errors when Group or Member has had a MemberID column added via extension.