### PR TITLE
Update SQL to remove ambiguity

### DIFF
--- a/code/model/Subsite.php
+++ b/code/model/Subsite.php
@@ -488,7 +488,7 @@ class Subsite extends DataObject
 			INNER JOIN \"Group\" ON \"Group\".\"ID\" = \"Permission\".\"GroupID\" AND \"Group\".\"AccessAllSubsites\" = 1
 			INNER JOIN \"Group_Members\" ON \"Group_Members\".\"GroupID\" = \"Permission\".\"GroupID\"
 			WHERE \"Permission\".\"Code\" IN ('$SQL_perms')
-			AND \"MemberID\" = {$memberID}
+			AND \"Group_Members\".\"MemberID\" = {$memberID}
 		")->value();
 
         // Count this user's groups which have a role that can access the main site
@@ -501,7 +501,7 @@ class Subsite extends DataObject
 			INNER JOIN \"PermissionRoleCode\" ON \"PermissionRole\".\"ID\"=\"PermissionRoleCode\".\"RoleID\"
 			WHERE \"PermissionRoleCode\".\"Code\" IN ('$SQL_perms')
 			AND \"Group\".\"AccessAllSubsites\" = 1
-			AND \"MemberID\" = {$memberID}
+			AND \"Group_Members\".\"MemberID\" = {$memberID}
 		")->value();
 
         // There has to be at least one that allows access.


### PR DESCRIPTION
Avoids errors when a column named MemberID has been added to Group or Member via an extension.