### PR TITLE
Adjusting query used in getSubsiteIDForDomain

### DIFF
--- a/code/model/Subsite.php
+++ b/code/model/Subsite.php
@@ -198,7 +198,7 @@ class Subsite extends DataObject
             }
 
             $subsiteID = $subsiteIDs[0];
-        } elseif ($default = DataObject::get_one('Subsite', "\"DefaultSite\" = 1")) {
+        } elseif ($default = Subsite::get()->filter('DefaultSite', 1)->setQueriedColumns(array('ID'))->first()) {
             // Check for a 'default' subsite
             $subsiteID = $default->ID;
         } else {


### PR DESCRIPTION
Adjusting a query used in getSubsiteIDForDomain to prevent new DB fields being added to the SQL call if they are not yet added to the DB.

Context:

We have an extension in our project that adds a DB field to `Subsite`. We also have a module in our project (akismet) that triggers `Translatable->populateSiteConfigDefaults()`, which ends up triggering `Subsite::currentSubsiteID()` before our extension has been applied. This eventually ends up in calling the `Subsite->getSubsiteIDForDomain()` method and at the adjusted line of code, it creates a SQL query that references the new field which does not exist, so we cannot complete a `dev/build`.