### PR TITLE
NEW Add SubsiteState and initialisation middleware

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,1 +1,5 @@
 <?php
+
+use SilverStripe\Dev\Deprecation;
+
+Deprecation::notification_version('2.0', 'subsites');

--- a/_config/middleware.yml
+++ b/_config/middleware.yml
@@ -1,0 +1,10 @@
+---
+Name: subsitesmiddleware
+After:
+  - requestprocessors
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Control\Director:
+    properties:
+      Middlewares:
+        SubsitesStateMiddleware: %$SilverStripe\Subsites\Middleware\InitStateMiddleware

--- a/code/Middleware/InitStateMiddleware.php
+++ b/code/Middleware/InitStateMiddleware.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SilverStripe\Subsites\Middleware;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Middleware\HTTPMiddleware;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Subsites\Model\Subsite;
+use SilverStripe\Subsites\State\SubsiteState;
+
+class InitStateMiddleware implements HTTPMiddleware
+{
+    public function process(HTTPRequest $request, callable $delegate)
+    {
+        $state = SubsiteState::create();
+        Injector::inst()->registerService($state);
+
+        $state->setSubsiteId($this->detectSubsiteId($request));
+
+        return $delegate($request);
+    }
+
+    /**
+     * Use the given request to detect the current subsite ID
+     *
+     * @param  HTTPRequest $request
+     * @return int
+     */
+    protected function detectSubsiteId(HTTPRequest $request)
+    {
+        $id = null;
+
+        if ($request->getVar('SubsiteID')) {
+            $id = (int) $request->getVar('SubsiteID');
+        }
+
+        if (Subsite::$use_session_subsiteid) {
+            $id = $request->getSession()->get('SubsiteID');
+        }
+
+        if ($id === null) {
+            $id = Subsite::getSubsiteIDForDomain();
+        }
+
+        return (int) $id;
+    }
+}

--- a/code/State/SubsiteState.php
+++ b/code/State/SubsiteState.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SilverStripe\Subsites\State;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
+
+/**
+ * SubsiteState provides static access to the current state for subsite related data during a request
+ */
+class SubsiteState
+{
+    use Injectable;
+
+    /**
+     * @var int|null
+     */
+    protected $subsiteId;
+
+    /**
+     * Get the current subsite ID
+     *
+     * @return int|null
+     */
+    public function getSubsiteId()
+    {
+        return $this->subsiteId;
+    }
+
+    /**
+     * Set the current subsite ID
+     *
+     * @param int $id
+     * @return $this
+     */
+    public function setSubsiteId($id)
+    {
+        $this->subsiteId = (int) $id;
+
+        return $this;
+    }
+
+    /**
+     * Perform a given action within the context of a new, isolated state. Modifications are temporary
+     * and the existing state will be restored afterwards.
+     *
+     * @param callable $callback Callback to run. Will be passed the nested state as a parameter
+     * @return mixed Result of callback
+     */
+    public function withState(callable $callback)
+    {
+        $newState = clone $this;
+        try {
+            Injector::inst()->registerService($newState);
+            return $callback($newState);
+        } finally {
+            Injector::inst()->registerService($this);
+        }
+    }
+}

--- a/code/extensions/CMSPageAddControllerExtension.php
+++ b/code/extensions/CMSPageAddControllerExtension.php
@@ -3,14 +3,14 @@
 namespace SilverStripe\Subsites\Extensions;
 
 use SilverStripe\Core\Extension;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HiddenField;
-use SilverStripe\Subsites\Model\Subsite;
+use SilverStripe\Subsites\State\SubsiteState;
 
 class CMSPageAddControllerExtension extends Extension
 {
-
-    public function updatePageOptions(&$fields)
+    public function updatePageOptions(FieldList $fields)
     {
-        $fields->push(new HiddenField('SubsiteID', 'SubsiteID', Subsite::currentSubsiteID()));
+        $fields->push(HiddenField::create('SubsiteID', 'SubsiteID', SubsiteState::singleton()->getSubsiteId()));
     }
 }

--- a/code/extensions/GroupSubsites.php
+++ b/code/extensions/GroupSubsites.php
@@ -15,6 +15,7 @@ use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Subsites\Model\Subsite;
+use SilverStripe\Subsites\State\SubsiteState;
 
 /**
  * Extension for the Group object to add subsites support
@@ -154,10 +155,10 @@ class GroupSubsites extends DataExtension implements PermissionProvider
 
         // If you're querying by ID, ignore the sub-site - this is a bit ugly...
         if (!$query->filtersOnID()) {
-            /*if($context = DataObject::context_obj()) $subsiteID = (int)$context->SubsiteID;
-
-            else */
-            $subsiteID = (int)Subsite::currentSubsiteID();
+            $subsiteID = SubsiteState::singleton()->getSubsiteId();
+            if ($subsiteID === null) {
+                return;
+            }
 
             // Don't filter by Group_Subsites if we've already done that
             $hasGroupSubsites = false;
@@ -198,7 +199,7 @@ class GroupSubsites extends DataExtension implements PermissionProvider
     {
         // New record test approximated by checking whether the ID has changed.
         // Note also that the after write test is only used when we're *not* on a subsite
-        if ($this->owner->isChanged('ID') && !Subsite::currentSubsiteID()) {
+        if ($this->owner->isChanged('ID') && !SubsiteState::singleton()->getSubsiteId()) {
             $this->owner->AccessAllSubsites = 1;
         }
     }
@@ -207,7 +208,7 @@ class GroupSubsites extends DataExtension implements PermissionProvider
     {
         // New record test approximated by checking whether the ID has changed.
         // Note also that the after write test is only used when we're on a subsite
-        if ($this->owner->isChanged('ID') && $currentSubsiteID = Subsite::currentSubsiteID()) {
+        if ($this->owner->isChanged('ID') && $currentSubsiteID = SubsiteState::singleton()->getSubsiteId()) {
             $subsites = $this->owner->Subsites();
             $subsites->add($currentSubsiteID);
         }

--- a/code/extensions/SiteConfigSubsites.php
+++ b/code/extensions/SiteConfigSubsites.php
@@ -9,6 +9,7 @@ use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\Subsites\Model\Subsite;
+use SilverStripe\Subsites\State\SubsiteState;
 
 /**
  * Extension for the SiteConfig object to add subsites support
@@ -41,7 +42,10 @@ class SiteConfigSubsites extends DataExtension
             }
         }
 
-        $subsiteID = (int)Subsite::currentSubsiteID();
+        $subsiteID = SubsiteState::singleton()->getSubsiteId();
+        if ($subsiteID === null) {
+            return;
+        }
 
         $froms = $query->getFrom();
         $froms = array_keys($froms);
@@ -55,7 +59,7 @@ class SiteConfigSubsites extends DataExtension
     public function onBeforeWrite()
     {
         if ((!is_numeric($this->owner->ID) || !$this->owner->ID) && !$this->owner->SubsiteID) {
-            $this->owner->SubsiteID = Subsite::currentSubsiteID();
+            $this->owner->SubsiteID = SubsiteState::singleton()->getSubsiteId();
         }
     }
 
@@ -64,11 +68,11 @@ class SiteConfigSubsites extends DataExtension
      */
     public function cacheKeyComponent()
     {
-        return 'subsite-' . Subsite::currentSubsiteID();
+        return 'subsite-' . SubsiteState::singleton()->getSubsiteId();
     }
 
     public function updateCMSFields(FieldList $fields)
     {
-        $fields->push(new HiddenField('SubsiteID', 'SubsiteID', Subsite::currentSubsiteID()));
+        $fields->push(HiddenField::create('SubsiteID', 'SubsiteID', SubsiteState::singleton()->getSubsiteId()));
     }
 }

--- a/tests/php/LeftAndMainSubsitesTest.php
+++ b/tests/php/LeftAndMainSubsitesTest.php
@@ -10,6 +10,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Security\Member;
 use SilverStripe\Subsites\Model\Subsite;
+use SilverStripe\Subsites\State\SubsiteState;
 
 class LeftAndMainSubsitesTest extends FunctionalTest
 {
@@ -24,7 +25,7 @@ class LeftAndMainSubsitesTest extends FunctionalTest
     protected function objFromFixture($className, $identifier)
     {
         Subsite::disable_subsite_filter(true);
-        $obj = parent::objFromFixture($classname, $identifier);
+        $obj = parent::objFromFixture($className, $identifier);
         Subsite::disable_subsite_filter(false);
 
         return $obj;
@@ -71,13 +72,13 @@ class LeftAndMainSubsitesTest extends FunctionalTest
 
         foreach ($ids as $id) {
             Subsite::changeSubsite($id);
-            $this->assertEquals($id, Subsite::currentSubsiteID());
+            $this->assertEquals($id, SubsiteState::singleton()->getSubsiteId());
 
             $left = new LeftAndMain();
             $this->assertTrue($left->canView(), "Admin user can view subsites LeftAndMain with id = '$id'");
             $this->assertEquals(
                 $id,
-                Subsite::currentSubsiteID(),
+                SubsiteState::singleton()->getSubsiteId(),
                 'The current subsite has not been changed in the process of checking permissions for admin user.'
             );
         }
@@ -86,7 +87,6 @@ class LeftAndMainSubsitesTest extends FunctionalTest
     public function testShouldChangeSubsite()
     {
         $l = new LeftAndMain();
-        Config::nest();
 
         Config::modify()->set(CMSPageEditController::class, 'treats_subsite_0_as_global', false);
         $this->assertTrue($l->shouldChangeSubsite(CMSPageEditController::class, 0, 5));
@@ -99,7 +99,5 @@ class LeftAndMainSubsitesTest extends FunctionalTest
         $this->assertFalse($l->shouldChangeSubsite(CMSPageEditController::class, 0, 0));
         $this->assertTrue($l->shouldChangeSubsite(CMSPageEditController::class, 1, 5));
         $this->assertFalse($l->shouldChangeSubsite(CMSPageEditController::class, 1, 1));
-
-        Config::unnest();
     }
 }

--- a/tests/php/SiteTreeSubsitesTest.php
+++ b/tests/php/SiteTreeSubsitesTest.php
@@ -8,7 +8,6 @@ use SilverStripe\CMS\Controllers\ModelAsController;
 use SilverStripe\ErrorPage\ErrorPage;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Director;
-use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
 use SilverStripe\Forms\FieldList;
@@ -107,7 +106,8 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         $subsite2 = $this->objFromFixture(Subsite::class, 'subsite2');
 
         // Cant pass member as arguments to canEdit() because of GroupSubsites
-        Session::set('loggedInAs', $admin->ID);
+        $this->logInAs($admin);
+
         $this->assertTrue(
             (bool)$subsite1page->canEdit(),
             'Administrators can edit all subsites'
@@ -116,13 +116,13 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         // @todo: Workaround because GroupSubsites->augmentSQL() is relying on session state
         Subsite::changeSubsite($subsite1);
 
-        Session::set('loggedInAs', $subsite1member->ID);
+        $this->logInAs($subsite1member->ID);
         $this->assertTrue(
             (bool)$subsite1page->canEdit(),
             'Members can edit pages on a subsite if they are in a group belonging to this subsite'
         );
 
-        Session::set('loggedInAs', $subsite2member->ID);
+        $this->logInAs($subsite2member->ID);
         $this->assertFalse(
             (bool)$subsite1page->canEdit(),
             'Members cant edit pages on a subsite if they are not in a group belonging to this subsite'
@@ -169,8 +169,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
 
     public function testPageTypesBlacklistInClassDropdown()
     {
-        $editor = $this->objFromFixture(Member::class, 'editor');
-        Session::set('loggedInAs', $editor->ID);
+        $this->logInAs('editor');
 
         $s1 = $this->objFromFixture(Subsite::class, 'domaintest1');
         $s2 = $this->objFromFixture(Subsite::class, 'domaintest2');
@@ -241,8 +240,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
 
     public function testPageTypesBlacklistInCMSMain()
     {
-        $editor = $this->objFromFixture(Member::class, 'editor');
-        Session::set('loggedInAs', $editor->ID);
+        $this->logInAs('editor');
 
         $cmsmain = new CMSMain();
 

--- a/tests/php/SubsiteFunctionalTest.php
+++ b/tests/php/SubsiteFunctionalTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace subsites\tests\php;
+namespace SilverStripe\Subsites\Tests;
 
 use Page;
 use SilverStripe\Dev\FunctionalTest;
@@ -22,7 +22,7 @@ class SubsiteFunctionalTest extends FunctionalTest
 
         $subsitePage = $this->objFromFixture(Page::class, 'contact');
         $this->get($subsitePage->AbsoluteLink());
-        $this->assertEquals($subsitePage->SubsiteID, Subsite::currentSubsiteID(), 'Subsite should be changed');
+        $this->assertEquals($subsitePage->SubsiteID, SubsiteState::singleton()->getSubsiteId(), 'Subsite should be changed');
         $this->assertEquals(
             SSViewer::get_themes(),
             $defaultThemes,
@@ -32,7 +32,7 @@ class SubsiteFunctionalTest extends FunctionalTest
         $pageWithTheme = $this->objFromFixture(Page::class, 'subsite1_contactus');
         $this->get($pageWithTheme->AbsoluteLink());
         $subsiteTheme = $pageWithTheme->Subsite()->Theme;
-        $this->assertEquals($pageWithTheme->SubsiteID, Subsite::currentSubsiteID(), 'Subsite should be changed');
+        $this->assertEquals($pageWithTheme->SubsiteID, SubsiteState::singleton()->getSubsiteId(), 'Subsite should be changed');
         $this->assertEquals(
             SSViewer::get_themes(),
             array_merge([$subsiteTheme], $defaultThemes),

--- a/tests/php/SubsiteTest.php
+++ b/tests/php/SubsiteTest.php
@@ -10,6 +10,8 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
 use SilverStripe\Subsites\Model\Subsite;
 use SilverStripe\Subsites\Model\SubsiteDomain;
+use SilverStripe\Subsites\State\SubsiteState;
+use UnexpectedValueException;
 
 class SubsiteTest extends BaseSubsiteTest
 {
@@ -59,7 +61,7 @@ class SubsiteTest extends BaseSubsiteTest
 
         // Test that changeSubsite is working
         Subsite::changeSubsite($template->ID);
-        $this->assertEquals($template->ID, Subsite::currentSubsiteID());
+        $this->assertEquals($template->ID, SubsiteState::singleton()->getSubsiteId());
         $tmplStaff = $this->objFromFixture('Page', 'staff');
         $tmplHome = DataObject::get_one('Page', "\"URLSegment\" = 'home'");
 


### PR DESCRIPTION
This adds a SubsiteState service which contains the subsite ID and can be accessed globally, adds detection via a middleware and replaces `Subsite::currentSubsiteID` use with it.

Added deprecation version and notice to `Subsite::currentSubsiteID`.