### PR TITLE
FIX Ensure delegated requests are continued when DB builds fail in middleware

### DIFF
--- a/code/Middleware/InitStateMiddleware.php
+++ b/code/Middleware/InitStateMiddleware.php
@@ -43,7 +43,8 @@ class InitStateMiddleware implements HTTPMiddleware
 
             return $delegate($request);
         } catch (DatabaseException $ex) {
-            // No-op, database is not ready
+            // Database is not ready
+            return $delegate($request);
         } finally {
             // Persist to the session if using the CMS
             if ($state->getUseSessions()) {


### PR DESCRIPTION
When a database exception is caught in middleware (database is not ready yet) we need to ensure that the next request (delegate) is returned to keep the request flow going, otherwise we get this on dev/build when first installing the module:

```
Fatal error: Call to a member function output() on null in /Users/robbieaverill/dev/ss4/framework/cli-script.php on line 23

Call Stack:
    0.0001     230808   1. {main}() /Users/robbieaverill/dev/ss4/framework/cli-script.php:0

ERROR [Alert]: Call to a member function output() on null
IN GET dev/build
Line 23 in /Users/robbieaverill/dev/ss4/framework/cli-script.php

Source
======
  14:  }
  15:  
  16:  // Build request and detect flush
  17:  $request = CLIRequestBuilder::createFromEnvironment();
  18:  
  19:  // Default application
  20:  $kernel = new CoreKernel(BASE_PATH);
  21:  $app = new HTTPApplication($kernel);
  22:  $response = $app->handle($request);
* 23:  $response->output();
```