### PR TITLE
FIX Update XHR controller hook selector and refactor getCMSFields to use scaffolding and separate tabs

### DIFF
--- a/javascript/LeftAndMain_Subsites.js
+++ b/javascript/LeftAndMain_Subsites.js
@@ -17,7 +17,7 @@
 		 */
 		$('.cms-container .cms-menu-list li a').entwine({
 			onclick: function(e) {
-				$('.cms-container').loadFragment('SubsiteXHRController', 'SubsiteList');
+				$('.cms-container').loadFragment('admin/subsite_xhr', 'SubsiteList');
 				this._super(e);
 			}
 		});
@@ -27,20 +27,17 @@
 		 */
 		$('.cms-container .SubsiteAdmin .cms-edit-form fieldset.ss-gridfield').entwine({
 			onreload: function(e) {
-				$('.cms-container').loadFragment('SubsiteXHRController', 'SubsiteList');
+				$('.cms-container').loadFragment('admin/subsite_xhr', 'SubsiteList');
 				this._super(e);
 			}
 		});
 
-
-
-
 		/*
 		 * Reload subsites dropdown when subsites are added or names are modified
 		 */
-		$('.cms-container .cms-content-fields .subsite-model').entwine({
+		$('.cms-container .tab.subsite-model').entwine({
 			onadd: function(e) {
-				$('.cms-container').loadFragment('SubsiteXHRController', 'SubsiteList');
+				$('.cms-container').loadFragment('admin/subsite_xhr', 'SubsiteList');
 				this._super(e);
 			}
 		});

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -49,6 +49,7 @@ en:
     SINGULARNAME: Subsite
     SiteConfigSubtitle: 'Your tagline here'
     SiteConfigTitle: 'Your Site Name'
+    SubsiteConfigurationHeader: 'Subsite Configuration'
     TabTitleConfig: Configuration
     ValidateTitle: 'Please add a "Title"'
   SilverStripe\Subsites\Model\SubsiteDomain:

--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -35,7 +35,6 @@ use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
 use SilverStripe\Subsites\State\SubsiteState;
 use SilverStripe\Versioned\Versioned;
-
 use UnexpectedValueException;
 
 /**
@@ -107,6 +106,59 @@ class Subsite extends DataObject
         'PrimaryDomain',
         'IsPublic'
     ];
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar(255)',
+        'RedirectURL' => 'Varchar(255)',
+        'DefaultSite' => 'Boolean',
+        'Theme' => 'Varchar',
+        'Language' => 'Varchar(6)',
+
+        // Used to hide unfinished/private subsites from public view.
+        // If unset, will default to true
+        'IsPublic' => 'Boolean',
+
+        // Comma-separated list of disallowed page types
+        'PageTypeBlacklist' => 'Text',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $has_many = [
+        'Domains' => SubsiteDomain::class,
+    ];
+
+    /**
+     * @var array
+     */
+    private static $belongs_many_many = [
+        'Groups' => Group::class,
+    ];
+
+    /**
+     * @var array
+     */
+    private static $defaults = [
+        'IsPublic' => 1
+    ];
+
+    /**
+     * @var array
+     */
+    private static $searchable_fields = [
+        'Title',
+        'Domains.Domain',
+        'IsPublic',
+    ];
+
+    /**
+     * @var string
+     */
+    private static $default_sort = '"Title" ASC';
 
     /**
      * Set allowed themes
@@ -583,59 +635,6 @@ class Subsite extends DataObject
     }
 
     /**
-     * @var array
-     */
-    private static $db = [
-        'Title' => 'Varchar(255)',
-        'RedirectURL' => 'Varchar(255)',
-        'DefaultSite' => 'Boolean',
-        'Theme' => 'Varchar',
-        'Language' => 'Varchar(6)',
-
-        // Used to hide unfinished/private subsites from public view.
-        // If unset, will default to true
-        'IsPublic' => 'Boolean',
-
-        // Comma-separated list of disallowed page types
-        'PageTypeBlacklist' => 'Text',
-    ];
-
-    /**
-     * @var array
-     */
-    private static $has_many = [
-        'Domains' => SubsiteDomain::class,
-    ];
-
-    /**
-     * @var array
-     */
-    private static $belongs_many_many = [
-        'Groups' => Group::class,
-    ];
-
-    /**
-     * @var array
-     */
-    private static $defaults = [
-        'IsPublic' => 1
-    ];
-
-    /**
-     * @var array
-     */
-    private static $searchable_fields = [
-        'Title',
-        'Domains.Domain',
-        'IsPublic',
-    ];
-
-    /**
-     * @var string
-     */
-    private static $default_sort = '"Title" ASC';
-
-    /**
      * @todo Possible security issue, don't grant edit permissions to everybody.
      * @param bool $member
      * @return bool
@@ -652,78 +651,83 @@ class Subsite extends DataObject
      */
     public function getCMSFields()
     {
-        if ($this->ID != 0) {
-            $domainTable = new GridField(
-                'Domains',
-                _t(__CLASS__ . '.DomainsListTitle', 'Domains'),
-                $this->Domains(),
-                GridFieldConfig_RecordEditor::create(10)
-            );
-        } else {
-            $domainTable = new LiteralField(
-                'Domains',
-                '<p>' . _t(
-                    __CLASS__ . '.DOMAINSAVEFIRST',
-                    'You can only add domains after saving for the first time'
-                ) . '</p>'
-            );
-        }
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            if ($this->exists()) {
+                // Add a GridField for domains to a new tab if the subsite has already been created
+                $fields->addFieldsToTab('Root.Domains', [
+                    GridField::create(
+                        'Domains',
+                        _t(__CLASS__ . '.DomainsListTitle', 'Domains'),
+                        $this->Domains(),
+                        GridFieldConfig_RecordEditor::create(10)
+                    )
+                ]);
+            }
 
-        $languageSelector = new DropdownField(
-            'Language',
-            $this->fieldLabel('Language'),
-            Injector::inst()->get(IntlLocales::class)->getLocales()
-        );
+            // Remove the default scaffolded blacklist field, we replace it with a checkbox set field
+            // in a wrapper further down. The RedirectURL field is currently not in use.
+            $fields->removeByName(['PageTypeBlacklist', 'RedirectURL']);
 
+            // Add the heading to the top of the fields list
+            $fields->fieldByName('Root.Main')
+                ->unshift(HeaderField::create('ConfigForSubsiteHeaderField', 'Subsite Configuration'));
+
+            $fields->addFieldToTab('Root.Main', DropdownField::create(
+                'Language',
+                $this->fieldLabel('Language'),
+                Injector::inst()->get(IntlLocales::class)->getLocales()
+            ), 'DefaultSite');
+
+            $fields->addFieldsToTab('Root.Main', [
+                ToggleCompositeField::create(
+                    'PageTypeBlacklistToggle',
+                    _t(__CLASS__ . '.PageTypeBlacklistField', 'Disallow page types?'),
+                    [
+                        CheckboxSetField::create('PageTypeBlacklist', '', $this->getPageTypeMap())
+                    ]
+                )->setHeadingLevel(4),
+                HiddenField::create('ID', '', $this->ID),
+                HiddenField::create('IsSubsite', '', 1)
+            ]);
+
+            // If there are any themes available, add the dropdown
+            $themes = $this->allowedThemes();
+            if (!empty($themes)) {
+                $fields->addFieldToTab(
+                    'Root.Main',
+                    DropdownField::create('Theme', $this->fieldLabel('Theme'), $this->allowedThemes(), $this->Theme)
+                        ->setEmptyString(_t(__CLASS__ . '.ThemeFieldEmptyString', '-')),
+                    'PageTypeBlacklistToggle'
+                );
+            }
+
+            // Targetted by the XHR PJAX JavaScript to reload the subsite list in the CMS
+            $fields->fieldByName('Root.Main')->addExtraClass('subsite-model');
+
+            // We don't need the Groups many many tab
+            $fields->removeByName('Groups');
+        });
+
+        return parent::getCMSFields();
+    }
+
+    /**
+     * Return a list of the different page types available to the CMS
+     *
+     * @return array
+     */
+    public function getPageTypeMap()
+    {
         $pageTypeMap = [];
+
         $pageTypes = SiteTree::page_type_classes();
         foreach ($pageTypes as $pageType) {
             $pageTypeMap[$pageType] = singleton($pageType)->i18n_singular_name();
         }
+
         asort($pageTypeMap);
 
-        $fields = new FieldList(
-            $subsiteTabs = new TabSet(
-                'Root',
-                new Tab(
-                    'Configuration',
-                    _t(__CLASS__ . '.TabTitleConfig', 'Configuration'),
-                    HeaderField::create('ConfigForSubsiteHeaderField', 'Subsite Configuration'),
-                    TextField::create('Title', $this->fieldLabel('Title'), $this->Title),
-                    HeaderField::create(
-                        'DomainsForSubsiteHeaderField',
-                        _t(__CLASS__ . '.DomainsHeadline', 'Domains for this subsite')
-                    ),
-                    $domainTable,
-                    $languageSelector,
-                    // new TextField('RedirectURL', 'Redirect to URL', $this->RedirectURL),
-                    CheckboxField::create('DefaultSite', $this->fieldLabel('DefaultSite'), $this->DefaultSite),
-                    CheckboxField::create('IsPublic', $this->fieldLabel('IsPublic'), $this->IsPublic),
-                    ToggleCompositeField::create(
-                        'PageTypeBlacklistToggle',
-                        _t(__CLASS__ . '.PageTypeBlacklistField', 'Disallow page types?'),
-                        [CheckboxSetField::create('PageTypeBlacklist', '', $pageTypeMap)]
-                    )->setHeadingLevel(4)
-                )
-            ),
-            HiddenField::create('ID', '', $this->ID),
-            HiddenField::create('IsSubsite', '', 1)
-        );
-
-        // If there are any themes available, add the dropdown
-        $themes = $this->allowedThemes();
-        if (!empty($themes)) {
-            $fields->addFieldToTab(
-                'Root.Configuration',
-                DropdownField::create('Theme', $this->fieldLabel('Theme'), $this->allowedThemes(), $this->Theme)
-                ->setEmptyString(_t(__CLASS__ . '.ThemeFieldEmptyString', '-'))
-            );
-        }
-
-        $subsiteTabs->addExtraClass('subsite-model');
-
-        $this->extend('updateCMSFields', $fields);
-        return $fields;
+        return $pageTypeMap;
     }
 
     /**

--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -670,7 +670,10 @@ class Subsite extends DataObject
 
             // Add the heading to the top of the fields list
             $fields->fieldByName('Root.Main')
-                ->unshift(HeaderField::create('ConfigForSubsiteHeaderField', 'Subsite Configuration'));
+                ->unshift(HeaderField::create(
+                    'ConfigForSubsiteHeaderField',
+                    _t(__CLASS__ . '.SubsiteConfigurationHeader', 'Subsite Configuration')
+                ));
 
             $fields->addFieldToTab('Root.Main', DropdownField::create(
                 'Language',


### PR DESCRIPTION
This pull request does:

* Use default scaffolding for getCMSFields on Subsite class
* Remove previously not shown tabs and form fields due to default scaffolding
* Re-arrange CMS fields for UX consistency
* Move Domains GridField in Subsite CMS fields into its own tab
* Fix the PJAX fragment reloading for the subsite list in the CMS when certain actions (e.g. adding a subsite) are performed
* Moves Subsite's private statics to the top of the class (from the middle) so they're with their brothers and sisters