### PR TITLE
Subsite - allow canEdit to be extended

### DIFF
--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -637,6 +637,11 @@ class Subsite extends DataObject
      */
     public function canEdit($member = false)
     {
+        $extended = $this->extendedCan(__FUNCTION__, $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
will enable `canEdit()` to return something other than true