### PR TITLE
API Convert most of Subsite public statics to config properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=vendor/silverstripe/framework/phpcs.xml.dist src tests *.php ; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=vendor/silverstripe/framework/phpcs.xml.dist src tests *.php --ignore=host-map.php; fi
   - if [[ $BEHAT_TEST ]]; then vendor/bin/behat @subsites; fi
 
 after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Updating to be compatible with SilverStripe 4
 * Subsite specific theme is now added to default theme, as themes are now cascadable
+* Global subsite information moved to injectable `SubsiteState` singleton service
+* `FileExtension:::default_root_folders_global` converted to a configuration property
+* `Subsite::$check_is_public` converted to a configuration property
+* `Subsite::$strict_subdomain_matching` converted to a configuration property
+* `Subsite::$force_subsite` deprecated and will be removed in future -  use `SubsiteState::singleton()->withState()` instead
+* `Subsite::$write_hostmap` converted to a configuration property
+* `Subsite::$allowed_themes` made protected
 
 ## [1.2.3]
 

--- a/src/Extensions/FileSubsites.php
+++ b/src/Extensions/FileSubsites.php
@@ -16,9 +16,13 @@ use SilverStripe\Subsites\State\SubsiteState;
  */
 class FileSubsites extends DataExtension
 {
-    // If this is set to true, all folders created will be default be
-    // considered 'global', unless set otherwise
-    public static $default_root_folders_global = false;
+    /**
+     * If this is set to true, all folders created will be default be considered 'global', unless set otherwise
+     *
+     * @config
+     * @var bool
+     */
+    private static $default_root_folders_global = false;
 
     private static $has_one = [
         'Subsite' => Subsite::class,
@@ -81,7 +85,7 @@ class FileSubsites extends DataExtension
     public function onBeforeWrite()
     {
         if (!$this->owner->ID && !$this->owner->SubsiteID) {
-            if (self::$default_root_folders_global) {
+            if ($this->owner->config()->get('default_root_folders_global')) {
                 $this->owner->SubsiteID = 0;
             } else {
                 $this->owner->SubsiteID = SubsiteState::singleton()->getSubsiteId();

--- a/tests/php/BaseSubsiteTest.php
+++ b/tests/php/BaseSubsiteTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Subsites\Tests;
 
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Subsites\Model\Subsite;
 use SilverStripe\Subsites\State\SubsiteState;
@@ -13,6 +14,7 @@ class BaseSubsiteTest extends SapphireTest
         parent::setUp();
 
         SubsiteState::singleton()->setUseSessions(true);
+        Config::modify()->set(Subsite::class, 'write_hostmap', false);
         Subsite::$force_subsite = null;
     }
 

--- a/tests/php/FileSubsitesTest.php
+++ b/tests/php/FileSubsitesTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Subsites\Tests;
 
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Subsites\Extensions\FileSubsites;
 use SilverStripe\Subsites\Model\Subsite;
@@ -31,7 +32,7 @@ class FileSubsitesTest extends BaseSubsiteTest
         $this->logInAs('admin');
 
         $subsite = $this->objFromFixture(Subsite::class, 'domaintest1');
-        FileSubsites::$default_root_folders_global = true;
+        Config::modify()->set(FileSubsites::class, 'default_root_folders_global', true);
 
         Subsite::changeSubsite(0);
         $file = new File();
@@ -47,7 +48,7 @@ class FileSubsitesTest extends BaseSubsiteTest
         $this->assertEquals((int)$file->SubsiteID, 0);
         $this->assertTrue($file->canEdit());
 
-        FileSubsites::$default_root_folders_global = false;
+        Config::modify()->set(FileSubsites::class, 'default_root_folders_global', false);
 
         Subsite::changeSubsite($subsite->ID);
         $file = new File();
@@ -58,7 +59,7 @@ class FileSubsitesTest extends BaseSubsiteTest
         $folder = new Folder();
         $folder->write();
         $this->assertEquals($folder->SubsiteID, $subsite->ID);
-        FileSubsites::$default_root_folders_global = true;
+        Config::modify()->set(FileSubsites::class, 'default_root_folders_global', true);
         $file = new File();
         $file->ParentID = $folder->ID;
         $file->onAfterUpload();

--- a/tests/php/SubsiteAdminTest.php
+++ b/tests/php/SubsiteAdminTest.php
@@ -13,6 +13,13 @@ class SubsiteAdminTest extends BaseSubsiteTest
 {
     protected static $fixture_file = 'SubsiteTest.yml';
 
+    protected function setUp()
+    {
+        parent::setUp();
+
+        Config::modify()->set(Subsite::class, 'write_hostmap', false);
+    }
+
     protected function adminLoggedInSession()
     {
         return new Session([
@@ -25,7 +32,6 @@ class SubsiteAdminTest extends BaseSubsiteTest
      */
     public function testBasicView()
     {
-        Config::modify()->set(Subsite::class, 'write_hostmap', false);
         $subsite1ID = $this->objFromFixture(Subsite::class, 'domaintest1')->ID;
 
         // Open the admin area logged in as admin

--- a/tests/php/SubsiteAdminTest.php
+++ b/tests/php/SubsiteAdminTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Subsites\Tests;
 use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\Session;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Security\Member;
 use SilverStripe\Subsites\Model\Subsite;
 
@@ -24,7 +25,7 @@ class SubsiteAdminTest extends BaseSubsiteTest
      */
     public function testBasicView()
     {
-        Subsite::$write_hostmap = false;
+        Config::modify()->set(Subsite::class, 'write_hostmap', false);
         $subsite1ID = $this->objFromFixture(Subsite::class, 'domaintest1')->ID;
 
         // Open the admin area logged in as admin

--- a/tests/php/SubsiteTest.php
+++ b/tests/php/SubsiteTest.php
@@ -30,7 +30,8 @@ class SubsiteTest extends BaseSubsiteTest
 
         Config::modify()
             ->set(Director::class, 'alternate_base_url', '/')
-            ->set(Subsite::class, 'strict_subdomain_matching', false);
+            ->set(Subsite::class, 'strict_subdomain_matching', false)
+            ->set(Subsite::class, 'write_hostmap', false);
 
         $this->origServer = $_SERVER;
     }
@@ -47,8 +48,6 @@ class SubsiteTest extends BaseSubsiteTest
      */
     public function testSubsiteCreation()
     {
-        Config::modify()->set(Subsite::class, 'write_hostmap', false);
-
         // Create the instance
         $template = $this->objFromFixture(Subsite::class, 'main');
 

--- a/tests/php/SubsiteTest.php
+++ b/tests/php/SubsiteTest.php
@@ -18,13 +18,6 @@ class SubsiteTest extends BaseSubsiteTest
     protected static $fixture_file = 'SubsiteTest.yml';
 
     /**
-     * Original value of {@see SubSite::$strict_subdomain_matching}
-     *
-     * @var bool
-     */
-    protected $origStrictSubdomainMatching = null;
-
-    /**
      * Original value of $_REQUEST
      *
      * @var array
@@ -35,16 +28,16 @@ class SubsiteTest extends BaseSubsiteTest
     {
         parent::setUp();
 
-        Config::modify()->set(Director::class, 'alternate_base_url', '/');
-        $this->origStrictSubdomainMatching = Subsite::$strict_subdomain_matching;
+        Config::modify()
+            ->set(Director::class, 'alternate_base_url', '/')
+            ->set(Subsite::class, 'strict_subdomain_matching', false);
+
         $this->origServer = $_SERVER;
-        Subsite::$strict_subdomain_matching = false;
     }
 
     protected function tearDown()
     {
         $_SERVER = $this->origServer;
-        Subsite::$strict_subdomain_matching = $this->origStrictSubdomainMatching;
 
         parent::tearDown();
     }
@@ -54,7 +47,7 @@ class SubsiteTest extends BaseSubsiteTest
      */
     public function testSubsiteCreation()
     {
-        Subsite::$write_hostmap = false;
+        Config::modify()->set(Subsite::class, 'write_hostmap', false);
 
         // Create the instance
         $template = $this->objFromFixture(Subsite::class, 'main');
@@ -191,7 +184,7 @@ class SubsiteTest extends BaseSubsiteTest
             'www.wildcard.com' => false,
         ]);
 
-        Subsite::$strict_subdomain_matching = false;
+        Config::modify()->set(Subsite::class, 'strict_subdomain_matching', false);
 
         $this->assertEquals(
             $subsite1->ID,
@@ -214,7 +207,7 @@ class SubsiteTest extends BaseSubsiteTest
             'Doesn\'t match www prefix without strict check, even if a wildcard subdomain is in place'
         );
 
-        Subsite::$strict_subdomain_matching = true;
+        Config::modify()->set(Subsite::class, 'strict_subdomain_matching', true);
 
         $this->assertEquals(
             $subsite1->ID,

--- a/tests/php/SubsitesVirtualPageTest.php
+++ b/tests/php/SubsitesVirtualPageTest.php
@@ -54,7 +54,7 @@ class SubsitesVirtualPageTest extends BaseSubsiteTest
     // Attempt to bring main:linky to subsite2:linky
     public function testVirtualPageFromAnotherSubsite()
     {
-        Subsite::$write_hostmap = false;
+        Config::modify()->set(Subsite::class, 'write_hostmap', false);
 
         $subsite = $this->objFromFixture(Subsite::class, 'subsite2');
 
@@ -261,7 +261,7 @@ class SubsitesVirtualPageTest extends BaseSubsiteTest
     {
         $this->markTestIncomplete('@todo fix this test');
 
-        Subsite::$write_hostmap = false;
+        Config::modify()->set(Subsite::class, 'write_hostmap', false);
         $subsite1 = $this->objFromFixture(Subsite::class, 'subsite1');
         $subsite2 = $this->objFromFixture(Subsite::class, 'subsite2');
         Subsite::changeSubsite($subsite1->ID);

--- a/tests/php/SubsitesVirtualPageTest.php
+++ b/tests/php/SubsitesVirtualPageTest.php
@@ -29,6 +29,8 @@ class SubsitesVirtualPageTest extends BaseSubsiteTest
     {
         parent::setUp();
 
+        Config::modify()->set(Subsite::class, 'write_hostmap', false);
+
         // Set backend root to /DataDifferencerTest
         TestAssetStore::activate('SubsitesVirtualPageTest');
 
@@ -54,8 +56,6 @@ class SubsitesVirtualPageTest extends BaseSubsiteTest
     // Attempt to bring main:linky to subsite2:linky
     public function testVirtualPageFromAnotherSubsite()
     {
-        Config::modify()->set(Subsite::class, 'write_hostmap', false);
-
         $subsite = $this->objFromFixture(Subsite::class, 'subsite2');
 
         Subsite::changeSubsite($subsite->ID);
@@ -261,7 +261,6 @@ class SubsitesVirtualPageTest extends BaseSubsiteTest
     {
         $this->markTestIncomplete('@todo fix this test');
 
-        Config::modify()->set(Subsite::class, 'write_hostmap', false);
         $subsite1 = $this->objFromFixture(Subsite::class, 'subsite1');
         $subsite2 = $this->objFromFixture(Subsite::class, 'subsite2');
         Subsite::changeSubsite($subsite1->ID);


### PR DESCRIPTION
I've left `Subsite::$force_subsite` as a public static but deprecated it in favour of using the SubsiteState instead, and have also left `$disable_subsite_filter` the way it is because it's used in a few other modules (including the CMS). Ideally in the next major release this will become part of the SubsiteState as well.

Resolves #174