### PR TITLE
FIX Subsites VirtualPage link to edit main page and TreeDropdownField API implementations

### DIFF
--- a/javascript/SubsitesTreeDropdownField.js
+++ b/javascript/SubsitesTreeDropdownField.js
@@ -4,14 +4,14 @@
 		 * Choose a subsite from which to select pages.
 		 * Needs to clear tree dropdowns in case selection is changed.
 		 */
-		$('.subsitestreedropdownfield-chooser').entwine({
+        $('select.subsitestreedropdownfield-chooser').entwine({
 			onchange: function() {
 				// TODO Data binding between two fields
-				// TODO create resetField method on API instead
-				var fields = $('.SubsitesTreeDropdownField');
-				fields.setValue(null);
-				fields.setTitle(null);
-				fields.find('.tree-holder').empty();
+                const name = this.attr('name').replace('_SubsiteID', '');
+                let field = $('#Form_EditForm_' + name).first();
+                field.setValue(0);
+                field.refresh();
+                field.trigger('change');
 			}
 		});
 
@@ -20,12 +20,15 @@
 		 * before asking for the tree.
 		 */
 		$('.TreeDropdownField.SubsitesTreeDropdownField').entwine({
-			getRequestParams: function() {
-				var name = this.find(':input[type=hidden]:first').attr('name') + '_SubsiteID',
-					source = $('[name=' + name + ']'), params = {};
-				params[name] = source.length ? source.val() : null;
-				return params;
-			}
+            getAttributes() {
+                const fieldName = this.attr('id').replace('Form_EditForm_', '');
+                const subsiteID = $('#Form_EditForm_' + fieldName + '_SubsiteID option:selected').val();
+
+                let attributes = this._super();
+                attributes.data.urlTree += "?" + fieldName + "_SubsiteID=" + subsiteID;
+                attributes.data.cacheKey = attributes.data.cacheKey.substring(0, 19) + "_" + subsiteID;
+                return attributes;
+            }
 		});
 	});
 })(jQuery);

--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -118,21 +118,23 @@ class SiteTreeSubsites extends DataExtension
                     'SubsiteOperations',
                     _t(__CLASS__ . '.SubsiteOperations', 'Subsite Operations'),
                     [
-                        new DropdownField('CopyToSubsiteID', _t(
+                        DropdownField::create('CopyToSubsiteID', _t(
                             __CLASS__ . '.CopyToSubsite',
                             'Copy page to subsite'
                         ), $subsitesMap),
-                        new CheckboxField(
+                        CheckboxField::create(
                             'CopyToSubsiteWithChildren',
                             _t(__CLASS__ . '.CopyToSubsiteWithChildren', 'Include children pages?')
                         ),
-                        $copyAction = new FormAction(
+                        $copyAction = FormAction::create(
                             'copytosubsite',
                             _t(__CLASS__ . '.CopyAction', 'Copy')
                         )
                     ]
                 )->setHeadingLevel(4)
             );
+
+            $copyAction->addExtraClass('btn btn-primary font-icon-save ml-3');
 
             // @todo check if this needs re-implementation
 //            $copyAction->includeDefaultJS(false);

--- a/src/Forms/SubsitesTreeDropdownField.php
+++ b/src/Forms/SubsitesTreeDropdownField.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Subsites\Forms;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Forms\TreeDropdownField;
+use SilverStripe\Subsites\Model\Subsite;
 use SilverStripe\View\Requirements;
 use SilverStripe\Subsites\State\SubsiteState;
 
@@ -20,7 +21,10 @@ class SubsitesTreeDropdownField extends TreeDropdownField
         'tree'
     ];
 
-    protected $subsiteID = 0;
+    /**
+     * @var int
+     */
+    protected $subsiteId = 0;
 
     /**
      * Extra HTML classes
@@ -39,20 +43,42 @@ class SubsitesTreeDropdownField extends TreeDropdownField
         return $html;
     }
 
-    public function setSubsiteID($id)
+    /**
+     * Sets the subsite ID to use when generating the tree
+     *
+     * @param int $id
+     * @return $this
+     */
+    public function setSubsiteId($id)
     {
-        $this->subsiteID = $id;
+        $this->subsiteId = $id;
+        return $this;
     }
 
-    public function getSubsiteID()
+    /**
+     * Get the subsite ID to use when generating the tree
+     *
+     * @return int
+     */
+    public function getSubsiteId()
     {
-        return $this->subsiteID;
+        return $this->subsiteId;
     }
 
+    /**
+     * Get the CMS tree with the provided subsite ID applied to the state
+     *
+     * {@inheritDoc}
+     */
     public function tree(HTTPRequest $request)
     {
-        $results = SubsiteState::singleton()->withState(function () use ($request) {
-            SubsiteState::singleton()->setSubsiteId($this->subsiteID);
+        // Detect subsite ID from the request
+        if ($request->getVar($this->getName() . '_SubsiteID')) {
+            $this->setSubsiteId($request->getVar($this->getName() . '_SubsiteID'));
+        }
+
+        $results = SubsiteState::singleton()->withState(function (SubsiteState $newState) use ($request) {
+            $newState->setSubsiteId($this->getSubsiteId());
             return parent::tree($request);
         });
 


### PR DESCRIPTION
This PR fixes the redirection to edit a page from another subsite, and the SubsitesTreeDropdownField
implementation and Javascript API points to refresh the tree when changing the source subsite in
the dropdown of a virtual page.

Requires https://github.com/silverstripe/silverstripe-admin/pull/414

Fixes #298