### PR TITLE
Use injected CMSMain to prevent unit test error missing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,23 +14,23 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=PGSQL PHPUNIT_TEST=1
+      env: DB=PGSQL INSTALLER_VERSION=4.1.x-dev PHPUNIT_TEST=1
     - php: 7.2
-      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.0
-      env: DB=MYSQL BEHAT_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.x-dev BEHAT_TEST=1
   allow_failures:
     - php: 7.0
-      env: DB=MYSQL BEHAT_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.x-dev BEHAT_TEST=1
 
 before_script:
   - phpenv rehash
   - phpenv config-rm xdebug.ini
   - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer validate
-  - composer require silverstripe/installer 4.0.x-dev --no-update
+  - composer require silverstripe/installer $INSTALLER_VERSION --no-update
   - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.0.x-dev; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
   - echo "SS_BASE_URL=http://localhost:8080/" >> .env

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   - composer validate
   - composer require silverstripe/installer $INSTALLER_VERSION --no-update
   - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql:2.0.x-dev; fi
-  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
   - echo "SS_BASE_URL=http://localhost:8080/" >> .env
 
   # Behat bootstrapping

--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -19,6 +19,7 @@ use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\Subsites\Model\Subsite;
@@ -478,20 +479,17 @@ class SiteTreeSubsites extends DataExtension
     }
 
     /**
-     * @param Member
+     * @param Member $member
      * @return boolean|null
      */
     public function canCreate($member = null)
     {
         // Typically called on a singleton, so we're not using the Subsite() relation
         $subsite = Subsite::currentSubsite();
-
         if ($subsite && $subsite->exists() && $subsite->PageTypeBlacklist) {
-            $blacklist = str_replace(['[', '"', ']'], '', $subsite->PageTypeBlacklist);
-            $blacklist = str_replace(['\\\\'], '\\', $blacklist);
-            $blacklisted = explode(',', $blacklist);
+            $blacklist = Convert::json2array($subsite->PageTypeBlacklist) ?: [];
 
-            if (in_array(get_class($this->owner), $blacklisted)) {
+            if (in_array(get_class($this->owner), $blacklist)) {
                 return false;
             }
         }

--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -487,9 +487,13 @@ class SiteTreeSubsites extends DataExtension
         // Typically called on a singleton, so we're not using the Subsite() relation
         $subsite = Subsite::currentSubsite();
         if ($subsite && $subsite->exists() && $subsite->PageTypeBlacklist) {
-            $blacklist = Convert::json2array($subsite->PageTypeBlacklist) ?: [];
+            // SS 4.1: JSON encoded. SS 4.0, comma delimited
+            $blacklist = Convert::json2array($subsite->PageTypeBlacklist);
+            if ($blacklist === false) {
+                $blacklist = explode(',', $subsite->PageTypeBlacklist);
+            }
 
-            if (in_array(get_class($this->owner), $blacklist)) {
+            if (in_array(get_class($this->owner), (array) $blacklist)) {
                 return false;
             }
         }

--- a/tests/php/SiteTreeSubsitesTest.php
+++ b/tests/php/SiteTreeSubsitesTest.php
@@ -185,7 +185,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         $s2 = $this->objFromFixture(Subsite::class, 'domaintest2');
         $page = singleton(SiteTree::class);
 
-        $s1->PageTypeBlacklist = implode(',', [TestClassA::class, ErrorPage::class]);
+        $s1->PageTypeBlacklist = json_encode([TestClassA::class, ErrorPage::class]);
         $s1->write();
 
         Subsite::changeSubsite($s1);
@@ -257,7 +257,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         $s1 = $this->objFromFixture(Subsite::class, 'domaintest1');
         $s2 = $this->objFromFixture(Subsite::class, 'domaintest2');
 
-        $s1->PageTypeBlacklist = implode(',', [TestClassA::class, ErrorPage::class]);
+        $s1->PageTypeBlacklist = json_encode([TestClassA::class, ErrorPage::class]);
         $s1->write();
 
         Subsite::changeSubsite($s1);

--- a/tests/php/SiteTreeSubsitesTest.php
+++ b/tests/php/SiteTreeSubsitesTest.php
@@ -267,8 +267,12 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         $this->assertNotContains(TestClassB::class, $classes);
 
         Subsite::changeSubsite($s2);
-        $cmsmain->getHintsCache()->clear();
+        // SS 4.1 and above
+        if ($cmsmain->hasMethod('getHintsCache')) {
+            $cmsmain->getHintsCache()->clear();
+        }
         $hints = Convert::json2array($cmsmain->SiteTreeHints());
+
         $classes = $hints['Root']['disallowedChildren'];
         $this->assertNotContains(ErrorPage::class, $classes);
         $this->assertNotContains(TestClassA::class, $classes);

--- a/tests/php/SiteTreeSubsitesTest.php
+++ b/tests/php/SiteTreeSubsitesTest.php
@@ -252,7 +252,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
     {
         $this->logInAs('editor');
 
-        $cmsmain = new CMSMain();
+        $cmsmain = CMSMain::create();
 
         $s1 = $this->objFromFixture(Subsite::class, 'domaintest1');
         $s2 = $this->objFromFixture(Subsite::class, 'domaintest2');

--- a/tests/php/SiteTreeSubsitesTest.php
+++ b/tests/php/SiteTreeSubsitesTest.php
@@ -252,8 +252,6 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
     {
         $this->logInAs('editor');
 
-        $cmsmain = CMSMain::create();
-
         $s1 = $this->objFromFixture(Subsite::class, 'domaintest1');
         $s2 = $this->objFromFixture(Subsite::class, 'domaintest2');
 
@@ -261,6 +259,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         $s1->write();
 
         Subsite::changeSubsite($s1);
+        $cmsmain = CMSMain::create();
         $hints = Convert::json2array($cmsmain->SiteTreeHints());
         $classes = $hints['Root']['disallowedChildren'];
         $this->assertContains(ErrorPage::class, $classes);
@@ -268,6 +267,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         $this->assertNotContains(TestClassB::class, $classes);
 
         Subsite::changeSubsite($s2);
+        $cmsmain->getHintsCache()->clear();
         $hints = Convert::json2array($cmsmain->SiteTreeHints());
         $classes = $hints['Root']['disallowedChildren'];
         $this->assertNotContains(ErrorPage::class, $classes);

--- a/tests/php/SubsitesVirtualPageTest.php
+++ b/tests/php/SubsitesVirtualPageTest.php
@@ -21,10 +21,6 @@ class SubsitesVirtualPageTest extends BaseSubsiteTest
         'SubsitesVirtualPageTest.yml',
     ];
 
-    protected static $illegal_extensions = [
-        SiteTree::class => ['Translatable'] // @todo implement Translatable namespace
-    ];
-
     protected function setUp()
     {
         parent::setUp();


### PR DESCRIPTION
Fixes error:

```
Fatal error: Call to a member function get() on null in /path/cwp20rc2/vendor/silverstripe/cms/code/Controllers/CMSMain.php on line 1033
```

I'm expecting this to fail, but will wait to see what else it complains about.

Fixes #351 