### PR TITLE
FIX Versioned regressions

### DIFF
--- a/tests/php/SubsiteAdminFunctionalTest.php
+++ b/tests/php/SubsiteAdminFunctionalTest.php
@@ -11,9 +11,18 @@ use SilverStripe\Subsites\Model\Subsite;
 class SubsiteAdminFunctionalTest extends FunctionalTest
 {
     protected static $fixture_file = 'SubsiteTest.yml';
-    protected static $use_draft_site = true;
 
     protected $autoFollowRedirection = false;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        // Ensure all pages are published
+        /** @var Page $page */
+        foreach (Page::get() as $page) {
+            $page->publishSingle();
+        }
+    }
 
     /**
      * Helper: FunctionalTest is only able to follow redirection once, we want to go all the way.


### PR DESCRIPTION
This should fix the regressions in SS 4.x-dev where versioned stage params are added to the URL.

see https://github.com/silverstripe/silverstripe-cms/issues/1578