### PR TITLE
FIX Automatically create default SiteTree records for new subsites

### DIFF
--- a/code/model/Subsite.php
+++ b/code/model/Subsite.php
@@ -743,15 +743,34 @@ class Subsite extends DataObject
     }
 
     /**
-     * Whenever a Subsite is written, rewrite the hostmap
+     * Whenever a Subsite is written, rewrite the hostmap and create some default pages
      *
      * @return void
      */
     public function onAfterWrite()
     {
         Subsite::writeHostMap();
+        if ($this->isChanged('ID')) {
+			$this->createDefaultPages();
+		}
         parent::onAfterWrite();
     }
+
+	/**
+	 * Automatically create default pages for new subsites
+	 */
+    protected function createDefaultPages()
+	{
+		$currentSubsite = Subsite::currentSubsiteID();
+		Subsite::changeSubsite($this->ID);
+
+		// Silence DB schema output
+		DB::quiet();
+		$siteTree = new SiteTree();
+		$siteTree->requireDefaultRecords();
+
+		Subsite::changeSubsite($currentSubsite);
+	}
 
     /**
      * Return the primary domain of this site. Tries to "normalize" the domain name,

--- a/tests/SiteTreeSubsitesTest.php
+++ b/tests/SiteTreeSubsitesTest.php
@@ -13,6 +13,14 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         'SiteTree' => array('Translatable')
     );
 
+    public function setUp()
+	{
+		// We have our own home page fixtures, prevent the default one being created in this test suite.
+		Config::inst()->update('SiteTree', 'create_default_pages', false);
+
+		parent::setUp();
+	}
+
     public function testPagesInDifferentSubsitesCanShareURLSegment()
     {
         $subsiteMain = $this->objFromFixture('Subsite', 'main');

--- a/tests/SubsiteTest.php
+++ b/tests/SubsiteTest.php
@@ -442,4 +442,15 @@ class SubsiteTest extends BaseSubsiteTest
         $subsite2->activate();
         $this->assertEquals('MyNewAwesomePage', DataObject::get_by_id('Page', $page2->ID)->Title);
     }
+
+    public function testDefaultPageCreatedWhenCreatingSubsite()
+	{
+		$subsite = new Subsite();
+		$subsite->Title = 'New Subsite';
+		$subsite->write();
+		$subsite->activate();
+
+		$pages = SiteTree::get();
+		$this->assertGreaterThanOrEqual(1, $pages->count());
+	}
 }


### PR DESCRIPTION
Resolves #252 (for SS3). For SS4 we can modify the logic slightly:

```php
SubsiteState::singleton()->withState(function (SubsiteState $newState) {
    $newState->setSubsiteId($this->ID);

    DB::quiet();
    (new SiteTree)->requireDefaultRecords();
});
```

^ in unit tests and `Subsite::createDefaultPages`.

This will create a home page at least. The logic in `SiteTree::requireDefaultRecords` uses manual SQL queries to determine whether an about us or contact page exist, so that's unlikely to work here. We get a home page at least, which was the original requirement.