### PR TITLE
if the table names are not case sensitive this condition always thing…

### DIFF
--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -276,7 +276,7 @@ class Subsite extends DataObject
 
             /** @skipUpgrade */
             $domainTableName = $schema->tableName(SubsiteDomain::class);
-            if (!in_array($domainTableName, DB::table_list())) {
+            if (!in_array(strtolower($domainTableName), array_map("strtolower", DB::table_list())) ) { // case sensitive table names
                 // Table hasn't been created yet. Might be a dev/build, skip.
                 return 0;
             }


### PR DESCRIPTION
…s the table is hasn't been created.

We had this issue on a window XAMPP / WAMPP installation where mysql was not case sensitive, and the subsites were always ignored. 

This modification checks the lower case tables names against a lowercase array 