### PR TITLE
NEW Hide subsite selector dropdown if no subsites have been created yet

### DIFF
--- a/templates/SilverStripe/Admin/LeftAndMain_Menu.ss
+++ b/templates/SilverStripe/Admin/LeftAndMain_Menu.ss
@@ -5,7 +5,7 @@
         <% include SilverStripe\\Admin\\LeftAndMain_MenuLogo %>
         <% include SilverStripe\\Admin\\LeftAndMain_MenuStatus %>
 
-        <% if $ListSubsites %>
+        <% if $ListSubsites.Count > 1 %>
             <% include SilverStripe\\Subsites\\Controller\\SubsiteXHRController_subsitelist %>
         <% end_if %>
     </div>


### PR DESCRIPTION
Note that "Main site" is always included in the list of subsites, even though it is not an actual record

Resolves #368