### PR TITLE
FIX apply SubsiteID getVar to CMS Preview fetches

### DIFF
--- a/docs/en/technical.md
+++ b/docs/en/technical.md
@@ -28,5 +28,5 @@ This method is called when a pages are being copied between the main site or ano
 ### alternateAbsoluteLink
 This method modifies the absolute link to contain the valid subsite domain
 
-### alternatePreviewLink
+### updatePreviewLink
 This method modifies the preview link for the CMS.

--- a/javascript/LeftAndMain_Subsites.js
+++ b/javascript/LeftAndMain_Subsites.js
@@ -101,7 +101,7 @@
 
 			/**
 			 * Update links and forms with GET/POST SubsiteID param, so we remaing on the current subsite.
-			 * The initial link for the iframe comes from SiteTreeSubsites::alternatePreviewLink.
+			 * The initial link for the iframe comes from SiteTreeSubsites::updatePreviewLink.
 			 *
 			 * This is done so we can use the CMS domain for displaying previews so we prevent single-origin
 			 * violations and SSL cert problems that come up when iframing content from a different URL.

--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -382,17 +382,31 @@ class SiteTreeSubsites extends DataExtension
 
     /**
      * Use the CMS domain for iframed CMS previews to prevent single-origin violations
-     * and SSL cert problems.
-     * @param null $action
+     * and SSL cert problems. Always set SubsiteID to avoid errors because a page doesn't
+     * exist on the CMS domain.
+     *
+     * @param string &$link
+     * @param string|null $action
+     * @return string
+     */
+    public function updatePreviewLink(&$link, $action = null)
+    {
+        $url = Director::absoluteURL($this->owner->Link($action));
+        $link = HTTP::setGetVar('SubsiteID', $this->owner->SubsiteID, $url);
+        return $link;
+    }
+
+    /**
+     * This function is marked as deprecated for removal in 5.0.0 in silverstripe/cms
+     * so now simply passes execution to where the functionality exists for backwards compatiblity.
+     *
+     * @param string|null $action
      * @return string
      */
     public function alternatePreviewLink($action = null)
     {
-        $url = Director::absoluteURL($this->owner->Link());
-        if ($this->owner->SubsiteID) {
-            $url = HTTP::setGetVar('SubsiteID', $this->owner->SubsiteID, $url);
-        }
-        return $url;
+        $link = '';
+        return $this->updatePreviewLink($link, $action);
     }
 
     /**


### PR DESCRIPTION
A preview link must be loaded on the same domain the CMS is loaded
through, which was previously causing issues when a page (identified
via URLSegment) did not exist on the subsite domain. By _always_
including the identifier in the preview link, this should never happen.

Resolves #263 