### PR TITLE
Deprecate alternatePreviewLink function as per CMS

### DIFF
--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -399,6 +399,8 @@ class SiteTreeSubsites extends DataExtension
     /**
      * This function is marked as deprecated for removal in 5.0.0 in silverstripe/cms
      * so now simply passes execution to where the functionality exists for backwards compatiblity.
+     * CMS 4.0.0 SiteTree already throws a SilverStripe deprecation error before calling this function.
+     * @deprecated 2.2...3.0 use updatePreviewLink instead
      *
      * @param string|null $action
      * @return string


### PR DESCRIPTION
SilverStripe CMS 4.0.0 issues a deprecation notice before calling
alternatePreviewLink on any page that hasMethod (i.e. is applied via an
extension such as SiteTreeSubsites). Instead of double-issuing a notice,
we will just mark this as deprecated in the next minor version via
docblocks.

closes #263 (already resolved via #374)
as per https://github.com/silverstripe/silverstripe-subsites/pull/374#pullrequestreview-134226803