### PR TITLE
Add subsite switching and page publish behat tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.yml]
+[*.{yml,feature}]
 indent_size = 2
 
 [{.travis.yml,package.json,composer.json}]

--- a/tests/behat/features/preview-navigation.feature
+++ b/tests/behat/features/preview-navigation.feature
@@ -1,25 +1,27 @@
 Feature: Preview navigation
-    As a CMS user
-    I can navigate a subsite in the preview pane
-    In order to preview my content
+  As a CMS user
+  I can navigate a subsite in the preview pane
+  In order to preview my content
 
-    Background:
-        Given a "subsite" "My subsite"
-        And a "page" "My page" with "URLSegment"="my-page", "Content"="My page content <a name='aname'>aname</a><a href='other-page'>ahref</a>" and "Subsite"="=>SilverStripe\Subsites\Model\Subsite.My subsite"
-        And a "page" "Other page" with "URLSegment"="other-page", "Content"="Other page content <a href='my-page'>Goto my page></a>" and "Subsite"="=>SilverStripe\Subsites\Model\Subsite.My subsite"
-        Given a "member" "Joe" belonging to "Admin Group" with "Email"="joe@test.com" and "Password"="Password1"
-        And the "group" "Admin Group" has permissions "Full administrative rights"
-        And I log in with "joe@test.com" and "Password1"
+  Background:
+    Given a "subsite" "My subsite"
+    And a "page" "My page" with "URLSegment"="my-page", "Content"="My page content <a name='aname'>aname</a><a href='other-page'>ahref</a>" and "Subsite"="=>SilverStripe\Subsites\Model\Subsite.My subsite"
+    And a "page" "Other page" with "URLSegment"="other-page", "Content"="Other page content <a href='my-page'>Goto my page></a>" and "Subsite"="=>SilverStripe\Subsites\Model\Subsite.My subsite"
+    Given a "member" "Joe" belonging to "Admin Group" with "Email"="joe@test.com" and "Password"="Password1"
+    And the "group" "Admin Group" has permissions "Full administrative rights"
+    And I log in with "joe@test.com" and "Password1"
 
-    @javascript
-    Scenario: I can navigate the subsite preview
-        When I go to "admin"
-        And I select "My subsite" from "SubsitesSelect"
-        And I go to "admin/pages"
-        And I click on "My page" in the tree
-        And I set the CMS mode to "Preview mode"
-        And I follow "ahref" in preview
-        Then the preview contains "Other page content"
-        # We are already on the second page, follow a link to return to first one.
-        And I follow "Goto my page" in preview
-        Then the preview contains "My page content"
+  @javascript
+  Scenario: I can navigate the subsite preview
+    When I go to "admin"
+    And I select "My subsite" from "SubsitesSelect"
+    And I go to "admin/pages"
+    And I click on "My page" in the tree
+    And I set the CMS mode to "Preview mode"
+    And I follow "ahref" in preview
+    And I wait for 1 second
+    Then the preview contains "Other page content"
+    # We are already on the second page, follow a link to return to first one.
+    And I follow "Goto my page" in preview
+    And I wait for 1 second
+    Then the preview contains "My page content"

--- a/tests/behat/features/publish-a-page.feature
+++ b/tests/behat/features/publish-a-page.feature
@@ -1,0 +1,25 @@
+Feature: Publish a page
+  As a CMS user
+  I can author pages in a new subsite
+  So that I can separate my website content by site
+
+  Background:
+    Given a "subsite" "Subsite B"
+    And a "page" "My page" with "URLSegment"="my-page", "Content"="My page content"
+    And I am logged in with "ADMIN" permissions
+    Then I go to "admin/pages"
+
+  @javascript
+  Scenario: I can publish a new page
+    Given I select "Subsite B" from "SubsitesSelect"
+    When I press the "Add new" button
+    And I press the "Create" button
+    And I set the CMS mode to "Edit mode"
+    And I fill in the "Content" HTML field with "<p>Some test content</p>"
+    Then I should see a "Publish" button
+    And I should not see a "Published" button
+
+    When I press the "Publish" button
+    And I wait for 3 seconds
+    Then I should see a "Published" button
+    And I should see a "Saved" button

--- a/tests/behat/features/select-a-subsite.feature
+++ b/tests/behat/features/select-a-subsite.feature
@@ -6,7 +6,6 @@ Feature: Select a subsite
 
   Background:
     Given a "subsite" "Subsite B"
-    And a "subsite" "Subsite B"
     And a "page" "My page" with "URLSegment"="my-page", "Content"="My page content"
     And I am logged in with "ADMIN" permissions
     Then I go to "admin/pages"

--- a/tests/behat/features/select-a-subsite.feature
+++ b/tests/behat/features/select-a-subsite.feature
@@ -1,0 +1,22 @@
+@javascript
+Feature: Select a subsite
+  As a CMS user
+  I want to be able to select a subsite
+  So that I can edit content for a specific subsite
+
+  Background:
+    Given a "subsite" "Subsite B"
+    And a "subsite" "Subsite B"
+    And a "page" "My page" with "URLSegment"="my-page", "Content"="My page content"
+    And I am logged in with "ADMIN" permissions
+    Then I go to "admin/pages"
+
+  Scenario: Default site contains default pages
+    When I select "Main site" from "SubsitesSelect"
+    And I go to "admin/pages"
+    Then I should see "My page" in the tree
+
+  Scenario: I can switch to another subsite
+    When I select "Subsite B" from "SubsitesSelect"
+    And I go to "admin/pages"
+    Then I should not see "My page" in the tree


### PR DESCRIPTION
This adds a new behat test feature for switching between subsites in the CMS, and adds a test that proves the bug in #355 (edit: only in CWP context).

This PR is just adding behat features now