### PR TITLE
FIX CMS permission checks for subsite are now handled in the state context

### DIFF
--- a/src/Controller/SubsiteXHRController.php
+++ b/src/Controller/SubsiteXHRController.php
@@ -27,23 +27,11 @@ class SubsiteXHRController extends LeftAndMain
             return true;
         }
 
-        if (Subsite::all_accessible_sites()->count() > 0) {
+        if (Subsite::all_accessible_sites(true, 'Main site', $member)->count() > 0) {
             return true;
         }
 
         return false;
-    }
-
-    /**
-     * Allow access if user allowed into the CMS at all.
-     */
-    public function canAccess()
-    {
-        // Allow if any cms access is available
-        return Permission::check([
-            'CMS_ACCESS', // Supported by 3.1.14 and up
-            'CMS_ACCESS_LeftAndMain'
-        ]);
     }
 
     public function getResponseNegotiator()

--- a/src/Extensions/GroupSubsites.php
+++ b/src/Extensions/GroupSubsites.php
@@ -90,7 +90,7 @@ class GroupSubsites extends DataExtension implements PermissionProvider
             // Interface is different if you have the rights to modify subsite group values on
             // all subsites
             if (isset($subsiteMap[0])) {
-                $fields->addFieldToTab('Root.Subsites', new OptionsetField(
+                $fields->addFieldToTab('Root.Subsites', OptionsetField::create(
                     'AccessAllSubsites',
                     _t(__CLASS__ . '.ACCESSRADIOTITLE', 'Give this group access to'),
                     [
@@ -100,20 +100,20 @@ class GroupSubsites extends DataExtension implements PermissionProvider
                 ));
 
                 unset($subsiteMap[0]);
-                $fields->addFieldToTab('Root.Subsites', new CheckboxSetField(
+                $fields->addFieldToTab('Root.Subsites', CheckboxSetField::create(
                     'Subsites',
                     '',
                     $subsiteMap
                 ));
             } else {
                 if (sizeof($subsiteMap) <= 1) {
-                    $fields->addFieldToTab('Root.Subsites', new ReadonlyField(
+                    $fields->addFieldToTab('Root.Subsites', ReadonlyField::create(
                         'SubsitesHuman',
                         _t(__CLASS__ . '.ACCESSRADIOTITLE', 'Give this group access to'),
                         reset($subsiteMap)
                     ));
                 } else {
-                    $fields->addFieldToTab('Root.Subsites', new CheckboxSetField(
+                    $fields->addFieldToTab('Root.Subsites', CheckboxSetField::create(
                         'Subsites',
                         _t(__CLASS__ . '.ACCESSRADIOTITLE', 'Give this group access to'),
                         $subsiteMap

--- a/src/Extensions/LeftAndMainSubsites.php
+++ b/src/Extensions/LeftAndMainSubsites.php
@@ -88,11 +88,6 @@ class LeftAndMainSubsites extends LeftAndMainExtension
         $accessibleSubsites = ArrayList::create();
         $subsites = Subsite::all_sites($includeMainSite, $mainSiteTitle);
 
-        // Check whether we have any subsites
-        if (!$subsites->exists()) {
-            return $accessibleSubsites;
-        }
-
         foreach ($subsites as $subsite) {
             /** @var Subsite $subsite */
             $canAccess = SubsiteState::singleton()
@@ -211,7 +206,7 @@ class LeftAndMainSubsites extends LeftAndMainExtension
     public function canAccess()
     {
         // Allow us to accept a Member object passed in as an argument without breaking semver
-        $passedMember = func_get_args() ? func_get_arg(0) : null;
+        $passedMember = func_num_args() ? func_get_arg(0) : null;
 
         // Admin can access everything, no point in checking.
         $member = $passedMember ?: Security::getCurrentUser();
@@ -249,6 +244,7 @@ class LeftAndMainSubsites extends LeftAndMainExtension
             $groupSubsiteIds = $group->Subsites()->column('ID');
             if (in_array($currentSubsiteId, $groupSubsiteIds)) {
                 $allowedInSubsite = true;
+                break;
             }
         }
 

--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Subsites\Extensions;
 
 use Page;
+use SilverStripe\CMS\Controllers\CMSPagesController;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
@@ -320,6 +321,11 @@ class SiteTreeSubsites extends DataExtension
         // Do not provide any input if there are no subsites configured
         if (!Subsite::get()->exists()) {
             return null;
+        }
+
+        // Check general subsite section access for CMS
+        if (CMSPagesController::singleton()->canAccess($member) === false) {
+            return false;
         }
 
         // Find the sites that this user has access to

--- a/tests/php/SiteTreeSubsitesTest.php
+++ b/tests/php/SiteTreeSubsitesTest.php
@@ -112,46 +112,41 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         $this->assertEquals($expected_path, $path);
     }
 
-    public function testCanEditSiteTree()
+    /**
+     * @dataProvider canEditProvider
+     *
+     * @param string $memberIdentifier
+     * @param string $subsiteIdentifier
+     * @param string $pageIdentifier
+     * @param bool $expected
+     * @param string $message
+     */
+    public function testCanEditSiteTree($memberIdentifier, $subsiteIdentifier, $pageIdentifier, $expected, $message)
     {
-        $admin = $this->objFromFixture(Member::class, 'admin');
-        $subsite1member = $this->objFromFixture(Member::class, 'subsite1member');
-        $subsite2member = $this->objFromFixture(Member::class, 'subsite2member');
-        $mainpage = $this->objFromFixture('Page', 'home');
-        $subsite1page = $this->objFromFixture('Page', 'subsite1_home');
-        $subsite2page = $this->objFromFixture('Page', 'subsite2_home');
-        $subsite1 = $this->objFromFixture(Subsite::class, 'subsite1');
-        $subsite2 = $this->objFromFixture(Subsite::class, 'subsite2');
+        $this->logInAs($memberIdentifier);
 
-        // Cant pass member as arguments to canEdit() because of GroupSubsites
-        $this->logInAs($admin);
+        /** @var Page $page */
+        $page = $this->objFromFixture(Page::class, $pageIdentifier);
 
-        $this->assertTrue(
-            (bool)$subsite1page->canEdit(),
-            'Administrators can edit all subsites'
-        );
+        if (is_string($subsiteIdentifier)) {
+            $subsiteIdentifier = $this->idFromFixture(Subsite::class, $subsiteIdentifier);
+        }
+        Subsite::changeSubsite($subsiteIdentifier);
 
-        // @todo: Workaround because GroupSubsites->augmentSQL() is relying on session state
-        Subsite::changeSubsite($subsite1);
+        $this->assertSame($expected, (bool) $page->canEdit(), $message);
+    }
 
-        $this->logInAs($subsite1member->ID);
-        $this->assertTrue(
-            (bool)$subsite1page->canEdit(),
-            'Members can edit pages on a subsite if they are in a group belonging to this subsite'
-        );
-
-        $this->logInAs($subsite2member->ID);
-        $this->assertFalse(
-            (bool)$subsite1page->canEdit(),
-            'Members cant edit pages on a subsite if they are not in a group belonging to this subsite'
-        );
-
-        // @todo: Workaround because GroupSubsites->augmentSQL() is relying on session state
-        Subsite::changeSubsite(0);
-        $this->assertFalse(
-            $mainpage->canEdit(),
-            'Members cant edit pages on the main site if they are not in a group allowing this'
-        );
+    /**
+     * @return array[]
+     */
+    public function canEditProvider()
+    {
+        return [
+            ['admin', 0, 'subsite1_home', true, 'Administrators can edit all subsites'],
+            ['subsite1member', 'subsite1', 'subsite1_home', true, 'Can edit on subsite if group belongs to subsite'],
+            ['subsite2member', 'subsite1', 'subsite1_home', false, 'Cannot edit on subsite if group doesn\'t belong'],
+            ['subsite2member', 0, 'home', false, 'Cannot edit pages on main site if not in correct group'],
+        ];
     }
 
     /**


### PR DESCRIPTION
We now check the subsite state for the context and validate it against the current member's group permissions using the SilverStripe ORM relationships instead of using SQL queries.

More granular permission checks e.g. canView etc are still up to data models to define and handle.

I think this is semver patch safe. I've used a workaround in `LeftAndMainSubsites::canAccess` to allow a passed member argument without adding it to the method signature (not semver safe).

Also the removal of `SubsiteXHRControllerTest` may be a little semver unsafe, but it falls back to calling the method from `LeftAndMainSubsites` so I'm OK with it.

Fixes #358