### PR TITLE
Change source of admin URL in getIsAdmin()

### DIFF
--- a/src/Middleware/InitStateMiddleware.php
+++ b/src/Middleware/InitStateMiddleware.php
@@ -62,7 +62,7 @@ class InitStateMiddleware implements HTTPMiddleware
     public function getIsAdmin(HTTPRequest $request)
     {
         $adminPaths = static::config()->get('admin_url_paths');
-        $adminPaths[] = AdminRootController::config()->get('url_base') . '/';
+        $adminPaths[] = AdminRootController::admin_url();
         $currentPath = rtrim($request->getURL(), '/') . '/';
         foreach ($adminPaths as $adminPath) {
             if (substr($currentPath, 0, strlen($adminPath)) === $adminPath) {


### PR DESCRIPTION
As per #394 
Change direct call to the AdminRootController config setting, using instead the admin_url() method on the class which provides detection via the Director rules, and the fallback to the config setting.