### PR TITLE
FIX Replace Convert JSON methods with json_* methods, deprecated from SilverStripe 4.4

### DIFF
--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -545,7 +545,7 @@ class SiteTreeSubsites extends DataExtension
         $subsite = Subsite::currentSubsite();
         if ($subsite && $subsite->exists() && $subsite->PageTypeBlacklist) {
             // SS 4.1: JSON encoded. SS 4.0, comma delimited
-            $blacklist = Convert::json2array($subsite->PageTypeBlacklist);
+            $blacklist = json_decode($subsite->PageTypeBlacklist, true);
             if ($blacklist === false) {
                 $blacklist = explode(',', $subsite->PageTypeBlacklist);
             }

--- a/tests/php/SiteTreeSubsitesTest.php
+++ b/tests/php/SiteTreeSubsitesTest.php
@@ -268,7 +268,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
 
         Subsite::changeSubsite($s1);
         $cmsmain = CMSMain::create();
-        $hints = Convert::json2array($cmsmain->SiteTreeHints());
+        $hints = json_decode($cmsmain->SiteTreeHints(), true);
         $classes = $hints['Root']['disallowedChildren'];
         $this->assertContains(ErrorPage::class, $classes);
         $this->assertContains(TestClassA::class, $classes);
@@ -279,7 +279,7 @@ class SiteTreeSubsitesTest extends BaseSubsiteTest
         if ($cmsmain->hasMethod('getHintsCache')) {
             $cmsmain->getHintsCache()->clear();
         }
-        $hints = Convert::json2array($cmsmain->SiteTreeHints());
+        $hints = json_decode($cmsmain->SiteTreeHints(), true);
 
         $classes = $hints['Root']['disallowedChildren'];
         $this->assertNotContains(ErrorPage::class, $classes);


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/8424