### PR TITLE
FIX Catching situation where database has no tables but it exists

### DIFF
--- a/src/Middleware/InitStateMiddleware.php
+++ b/src/Middleware/InitStateMiddleware.php
@@ -44,8 +44,10 @@ class InitStateMiddleware implements HTTPMiddleware
             return $delegate($request);
         } catch (DatabaseException $ex) {
             $message = $ex->getMessage();
-            if (strpos($message, 'No database selected') !== false) {
-                // Database is not ready, ignore and continue
+            if (strpos($message, 'No database selected') !== false
+                || preg_match('/\s*(table|relation) .* does(n\'t| not) exist/i', $message)
+            ) {
+                // Database is not ready, ignore and continue. Either it doesn't exist or it has no tables
                 return $delegate($request);
             }
             throw $ex;


### PR DESCRIPTION
Currently on platform it is possible to have a database existing but no tables within it. Currently the state middleware allows for database not existing (eg. when tasks are being run after a deployment) but not for the database existing but tables not existing.

This patch also ignores an error where it is complaining that the subsite table does not exist, matching the current error message from MySQL and PostgreSQL.