### PR TITLE
FIX Content editor group users can now insert links into contents while using subsites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ matrix:
     - php: 7.0
       env: DB=PGSQL INSTALLER_VERSION=4.1.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL INSTALLER_VERSION=4.1.x-dev BEHAT_TEST=1
-    - php: 7.2
       env: DB=MYSQL INSTALLER_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.2
-      env: DB=MYSQL INSTALLER_VERSION=4.x-dev BEHAT_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.3.x-dev BEHAT_TEST=1
+    - php: 7.3
+      env: DB=MYSQL INSTALLER_VERSION=4.x-dev PHPUNIT_TEST=1
 
 before_script:
   # Extra $PATH

--- a/src/Extensions/LeftAndMainSubsites.php
+++ b/src/Extensions/LeftAndMainSubsites.php
@@ -221,9 +221,11 @@ class LeftAndMainSubsites extends LeftAndMainExtension
         // Admin can access everything, no point in checking.
         $member = Security::getCurrentUser();
         if ($member
-            && (Permission::checkMember($member, 'ADMIN') // 'Full administrative rights'
-                || Permission::checkMember($member, 'CMS_ACCESS_LeftAndMain') // 'Access to all CMS sections'
-            )
+            && (Permission::checkMember($member, [
+                'ADMIN', // Full administrative rights
+                'CMS_ACCESS_LeftAndMain', // Access to all CMS sections
+                'CMS_ACCESS_CMSMain', // Access to CMS controllers
+            ]))
         ) {
             return true;
         }

--- a/tests/behat/features/insert-content-link.feature
+++ b/tests/behat/features/insert-content-link.feature
@@ -1,0 +1,29 @@
+# See https://github.com/silverstripe/silverstripe-subsites/issues/357
+Feature: Insert an internal link into content
+  As a CMS user
+  I can insert internal links into my content
+  So that I can direct users to different parts of my website
+
+  Background:
+    Given a "subsite" "Subsite B"
+    And a "page" "My page" with "URLSegment"="my-page", "Content"="My page content"
+    And a "page" "Another page" with "URLSegment"="another-page", "Content"="My other page content"
+    And I am logged in with "CMS_ACCESS_CMSMain" permissions
+    Then I go to "admin/pages"
+    And I click on "My page" in the tree
+
+  @javascript
+  Scenario: I can insert an internal link
+    # See "insert-a-link.feature" from silverstripe/cms
+    When I select "My page" in the "Content" HTML field
+    And I press the "Insert link" HTML field button
+    And I click "Page on this site" in the ".mce-menu" element
+    Then I should see an "form#Form_editorInternalLink" element
+    When I click "(Choose Page)" in the ".Select-multi-value-wrapper" element
+    And I click "Another page" in the ".treedropdownfield__menu" element
+    And I fill in "my desc" for "Link description"
+    And I press the "Insert" button
+    Then the "Content" HTML field should contain "<a title="my desc" href="[sitetree_link"
+    And the "Content" HTML field should contain "My page</a>"
+    # Required to avoid "unsaved changes" browser dialog
+    Then I press the "Save" button


### PR DESCRIPTION
This change allows users with CMSMain permissions to have access in LeftAndMainSubsites::canAccess(), since `ModalController` doesn't define its own permission codes, and usually modals are related to CMS content.

Fixes https://github.com/silverstripe/silverstripe-subsites/issues/357