### PR TITLE
FIX Adding an extension to ensure blacklisted page types are disallowed

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -14,6 +14,7 @@ SilverStripe\CMS\Controllers\ContentController:
 SilverStripe\CMS\Controllers\CMSPageAddController:
   extensions:
     - SilverStripe\Subsites\Extensions\CMSPageAddControllerExtension
+    - SilverStripe\Subsites\Extensions\PageAddBlacklistExtension
 
 SilverStripe\Admin\LeftAndMain:
   extensions:

--- a/src/Extensions/PageAddBlacklistExtension.php
+++ b/src/Extensions/PageAddBlacklistExtension.php
@@ -1,0 +1,38 @@
+<?php
+namespace SilverStripe\Subsites\Extensions;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\OptionsetField;
+use SilverStripe\Subsites\Model\Subsite;
+use SilverStripe\Subsites\State\SubsiteState;
+
+class PageAddBlacklistExtension extends Extension
+{
+    public function updatePageOptions(FieldList $fields)
+    {
+        /** @var Subsite $subsite */
+        $subsite = Subsite::currentSubsite();
+
+        // Exit early if no subsite is active
+        if (!$subsite || !$subsite->exists()) {
+            return;
+        }
+
+        // Pull the blacklist of pages
+        $blacklist = $subsite->parsePageTypeBlacklist();
+
+        // Break early if there's no blacklist
+        if (empty($blacklist)) {
+            return;
+        }
+
+        // And the field for page types
+        /** @var OptionsetField $pageTypeField */
+        $pageTypeField = $fields->dataFieldByName('PageType');
+
+        // Prune blacklisted items from the source
+        $pageTypes = array_diff_key($pageTypeField->getSource(), array_flip($blacklist));
+        $pageTypeField->setSource($pageTypes);
+    }
+}

--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -545,14 +545,9 @@ class SiteTreeSubsites extends DataExtension
     public function canCreate($member = null)
     {
         // Typically called on a singleton, so we're not using the Subsite() relation
+        /** @var Subsite $subsite */
         $subsite = Subsite::currentSubsite();
-        if ($subsite && $subsite->exists() && $subsite->PageTypeBlacklist) {
-            // SS 4.1: JSON encoded. SS 4.0, comma delimited
-            $blacklist = json_decode($subsite->PageTypeBlacklist, true);
-            if ($blacklist === false) {
-                $blacklist = explode(',', $subsite->PageTypeBlacklist);
-            }
-
+        if ($subsite && $subsite->exists() && ($blacklist = $subsite->parsePageTypeBlacklist())) {
             if (in_array(get_class($this->owner), (array) $blacklist)) {
                 return false;
             }

--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -36,7 +36,7 @@ use UnexpectedValueException;
  * A dynamically created subsite. SiteTree objects can now belong to a subsite.
  * You can simulate subsite access without setting up virtual hosts by appending ?SubsiteID=<ID> to the request.
  *
- * @package subsites
+ * @property string PageTypeBlacklist
  */
 class Subsite extends DataObject
 {
@@ -965,6 +965,29 @@ JS;
             LEFT JOIN "Group" ON "Group"."ID" = "Group_Members"."GroupID"
             LEFT JOIN "Permission" ON "Permission"."GroupID" = "Group"."ID"'
         );
+    }
+
+    /**
+     * Parses and returns an array of page types that have been blacklisted for this subsite. Returns null if the
+     * blacklist is not defined
+     *
+     * @return array|null
+     */
+    public function parsePageTypeBlacklist()
+    {
+        $raw = $this->getField('PageTypeBlacklist');
+
+        // SS 4.1: JSON encoded. SS 4.0, comma delimited
+        $blacklist = json_decode($raw, true);
+        if ($blacklist === false) {
+            $blacklist = explode(',', $raw);
+        }
+
+        if (empty($blacklist)) {
+            return null;
+        }
+
+        return $blacklist;
     }
 
     /**


### PR DESCRIPTION
Fixes #351

In my testing it seemed I was denied from creating pages with `canCreate` but you still got a full list of page types regardless of the subsite blacklist. This PR adds an extension to limit the list. This might be getting a bit close to the line of "too many impacting changes for a patch" - happy to retarget or alter the PR.