### PR TITLE
FIX Domains now default to "Automatic" protocol, and have the correct help description

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -47,13 +47,14 @@ en:
   SilverStripe\Subsites\Model\SubsiteDomain:
     DOMAIN: Domain
     DOMAIN_DESCRIPTION: 'Hostname of this subsite (exclude protocol). Allows wildcards (*).'
+    ISPRIMARY_DESCRIPTION: 'Mark this as the default domain for this subsite'
     IS_PRIMARY: 'Is Primary Domain?'
     PLURALNAME: 'Subsite Domains'
     PLURALS:
       one: 'A Subsite Domain'
       other: '{count} Subsite Domains'
     PROTOCOL_AUTOMATIC: Automatic
-    PROTOCOL_DESCRIPTION: 'Mark this as the default domain for this subsite'
+    PROTOCOL_DESCRIPTION: 'When generating links to this subsite, use the selected protocol. <br />Selecting ''Automatic'' means subsite links will default to the current protocol.'
     PROTOCOL_HTTP: 'http://'
     PROTOCOL_HTTPS: 'https://'
     Protocol: Protocol

--- a/src/Model/SubsiteDomain.php
+++ b/src/Model/SubsiteDomain.php
@@ -111,13 +111,14 @@ class SubsiteDomain extends DataObject
             self::PROTOCOL_HTTPS => _t(__CLASS__ . '.PROTOCOL_HTTPS', 'https://'),
             self::PROTOCOL_AUTOMATIC => _t(__CLASS__ . '.PROTOCOL_AUTOMATIC', 'Automatic')
         ];
-        $fields = new FieldList(
+        $fields = FieldList::create(
             WildcardDomainField::create('Domain', $this->fieldLabel('Domain'), null, 255)
                 ->setDescription(_t(
                     __CLASS__ . '.DOMAIN_DESCRIPTION',
                     'Hostname of this subsite (exclude protocol). Allows wildcards (*).'
                 )),
             OptionsetField::create('Protocol', $this->fieldLabel('Protocol'), $protocols)
+                ->setValue($this->Protocol ?: self::PROTOCOL_AUTOMATIC)
                 ->setDescription(_t(
                     __CLASS__ . '.PROTOCOL_DESCRIPTION',
                     'When generating links to this subsite, use the selected protocol. <br />' .
@@ -125,7 +126,7 @@ class SubsiteDomain extends DataObject
                 )),
             CheckboxField::create('IsPrimary', $this->fieldLabel('IsPrimary'))
                 ->setDescription(_t(
-                    __CLASS__ . '.PROTOCOL_DESCRIPTION',
+                    __CLASS__ . '.ISPRIMARY_DESCRIPTION',
                     'Mark this as the default domain for this subsite'
                 ))
         );


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-subsites/issues/251 and an issue where the "Mark this as the default domain for this subsite" description was also shown on the protocol option set as well as the "IsPrimary "checkbox