### PR TITLE
FIX allowed pagetypes displaying incorrectly when switching subsite

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -50,6 +50,7 @@ SilverStripe\Admin\SecurityAdmin:
 
 SilverStripe\CMS\Controllers\CMSMain:
   extensions:
+    - SilverStripe\Subsites\Extensions\HintsCacheKeyExtension
     - SilverStripe\Subsites\Extensions\SubsiteMenuExtension
 
 SilverStripe\CMS\Controllers\CMSPagesController:

--- a/src/Extensions/HintsCacheKeyExtension.php
+++ b/src/Extensions/HintsCacheKeyExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\Subsites\Extensions;
+
+use SilverStripe\CMS\Controllers\CMSMain;
+use SilverStripe\Core\Extension;
+use SilverStripe\Subsites\State\SubsiteState;
+
+/**
+ * This extension adds the current Subsite ID as an additional factor to the Hints Cßache Key, which is used to cache
+ * the Site Tree Hints (which include allowed pagetypes).
+ *
+ * @package SilverStripe\Subsites\Extensions
+ * @see CMSMain::generateHintsCacheKey()
+ */
+class HintsCacheKeyExtension extends Extension
+{
+    public function updateHintsCacheKey(&$baseKey)
+    {
+        $baseKey .= '_Subsite:' . SubsiteState::singleton()->getSubsiteId();
+    }
+}


### PR DESCRIPTION
Introduces an extension to add the current Subsite ID to the SiteTree Hints Cache Key so that the allowed pagetypes are correctly cached on a per-Subsite basis. Resolves #351.

This patch depends on [an update to the CMS module](https://github.com/silverstripe/silverstripe-cms/pull/2442) that provides this extension point. The code is inert when matched with existing CMS versions.