### PR TITLE
FIX LeftAndMainSubsites::canAccess() now accepts a Member argument and falls back to the session member

### DIFF
--- a/src/Extensions/LeftAndMainSubsites.php
+++ b/src/Extensions/LeftAndMainSubsites.php
@@ -215,11 +215,16 @@ class LeftAndMainSubsites extends LeftAndMainExtension
 
     /**
      * Check if the current controller is accessible for this user on this subsite.
+     *
+     * @param Member $member
      */
-    public function canAccess()
+    public function canAccess(Member $member = null)
     {
+        if (!$member) {
+            $member = Security::getCurrentUser();
+        }
+
         // Admin can access everything, no point in checking.
-        $member = Security::getCurrentUser();
         if ($member
             && (Permission::checkMember($member, [
                 'ADMIN', // Full administrative rights
@@ -238,10 +243,12 @@ class LeftAndMainSubsites extends LeftAndMainExtension
     /**
      * Prevent accessing disallowed resources. This happens after onBeforeInit has executed,
      * so all redirections should've already taken place.
+     *
+     * @param Member $member
      */
-    public function alternateAccessCheck()
+    public function alternateAccessCheck(Member $member = null)
     {
-        return $this->owner->canAccess();
+        return $this->owner->canAccess($member);
     }
 
     /**

--- a/tests/php/LeftAndMainSubsitesTest.php
+++ b/tests/php/LeftAndMainSubsitesTest.php
@@ -9,6 +9,7 @@ use SilverStripe\CMS\Controllers\CMSPageEditController;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Security\Member;
+use SilverStripe\Subsites\Extensions\LeftAndMainSubsites;
 use SilverStripe\Subsites\Model\Subsite;
 use SilverStripe\Subsites\State\SubsiteState;
 
@@ -99,5 +100,15 @@ class LeftAndMainSubsitesTest extends FunctionalTest
         $this->assertFalse($l->shouldChangeSubsite(CMSPageEditController::class, 0, 0));
         $this->assertTrue($l->shouldChangeSubsite(CMSPageEditController::class, 1, 5));
         $this->assertFalse($l->shouldChangeSubsite(CMSPageEditController::class, 1, 1));
+    }
+
+    public function testCanAccessWithPassedMember()
+    {
+        $memberID = $this->logInWithPermission('ADMIN');
+        $member = Member::get()->byID($memberID);
+
+        /** @var LeftAndMain&LeftAndMainSubsites $leftAndMain */
+        $leftAndMain = new LeftAndMain();
+        $this->assertTrue($leftAndMain->canAccess($member));
     }
 }


### PR DESCRIPTION
Access checks are provided with a Member argument, and should revert to using the session member if not provided. The subsites checks were not doing this, despite being provided with a Member argument. This caused an issue with multi-factor authentication where it delays setting the Member to the session until after MFA is verified.

This patch adds handling for a passed Member argument.

Fixes https://github.com/silverstripe/silverstripe-mfa/issues/204