### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Include the current SubsiteID as a hidden field on getCMSFields, or updateCMSFie
 	:::php
 	public function getCMSFields() {
 		$fields = parent::getCMSFields();
-		if(class_exists('Subsite')){
-			$fields->push(new HiddenField('SubsiteID','SubsiteID', Subsite::currentSubsiteID()));
+		if(class_exists(Subsite::class)){
+			$fields->push(new HiddenField('SubsiteID','SubsiteID', SubsiteState::singleton()->getSubsiteId()));
 		}
 		return $fields;
 	}


### PR DESCRIPTION
I am not quite sure if this is needed but i'd expect the code snipets to work with Silverstripe 4 if the requirement say Silverstripe 4. I testet it with SS 4.4.1
Subsite::currentSubsiteID() is deprecated.  class_exists needs namespace to work correctly