### PR TITLE
FIX Prevent undefined index notice when trying to determine HTTP_HOST during dev/build

### DIFF
--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -870,7 +870,7 @@ class Subsite extends DataObject
         }
 
         // If there are no objects, default to the current hostname
-        return isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'localhost';
+        return Director::host();
     }
 
     /**

--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -870,7 +870,7 @@ class Subsite extends DataObject
         }
 
         // If there are no objects, default to the current hostname
-        return $_SERVER['HTTP_HOST'];
+        return isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'localhost';
     }
 
     /**

--- a/src/Model/SubsiteDomain.php
+++ b/src/Model/SubsiteDomain.php
@@ -185,7 +185,7 @@ class SubsiteDomain extends DataObject
      */
     public function getSubstitutedDomain()
     {
-        $currentHost = $_SERVER['HTTP_HOST'];
+        $currentHost = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'localhost';
 
         // If there are wildcards in the primary domain (not recommended), make some
         // educated guesses about what to replace them with:

--- a/src/Model/SubsiteDomain.php
+++ b/src/Model/SubsiteDomain.php
@@ -185,7 +185,7 @@ class SubsiteDomain extends DataObject
      */
     public function getSubstitutedDomain()
     {
-        $currentHost = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'localhost';
+        $currentHost = Director::host();
 
         // If there are wildcards in the primary domain (not recommended), make some
         // educated guesses about what to replace them with:


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-subsites/issues/437

There's no host information available when run from command line because `CLIRequestBuilder` doesn't provide it, so we need to have a fallback to a sensible default.