### PR TITLE
ENH Add domain support for the main site.

### DIFF
--- a/src/Admin/SubsiteAdmin.php
+++ b/src/Admin/SubsiteAdmin.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Subsites\Forms\GridFieldSubsiteDetailForm;
 use SilverStripe\Subsites\Model\Subsite;
+use SilverStripe\Subsites\Model\SubsiteDomain;
 
 /**
  * Admin interface to manage and create {@link Subsite} instances.
@@ -15,7 +16,14 @@ use SilverStripe\Subsites\Model\Subsite;
  */
 class SubsiteAdmin extends ModelAdmin
 {
-    private static $managed_models = [Subsite::class];
+    private static $managed_models = [
+        Subsite::class => [
+            'title' => 'Subsites'
+        ],
+        SubsiteDomain::class => [
+            'title' => 'Main site domains'
+        ],
+    ];
 
     private static $url_segment = 'subsites';
 
@@ -31,11 +39,18 @@ class SubsiteAdmin extends ModelAdmin
     {
         $form = parent::getEditForm($id, $fields);
 
-        $grid = $form->Fields()->dataFieldByName(str_replace('\\', '-', Subsite::class));
-        if ($grid) {
-            $grid->getConfig()->getComponentByType(GridFieldPaginator::class)->setItemsPerPage(100);
-            $grid->getConfig()->removeComponentsByType(GridFieldDetailForm::class);
-            $grid->getConfig()->addComponent(new GridFieldSubsiteDetailForm());
+        if ($this->modelClass === Subsite::class) {
+            $grid = $form->Fields()->dataFieldByName(str_replace('\\', '-', Subsite::class));
+            if ($grid) {
+                $grid->getConfig()->getComponentByType(GridFieldPaginator::class)->setItemsPerPage(100);
+                $grid->getConfig()->removeComponentsByType(GridFieldDetailForm::class);
+                $grid->getConfig()->addComponent(new GridFieldSubsiteDetailForm());
+            }
+        }
+
+        if ($this->modelClass === SubsiteDomain::class) {
+            $grid = $form->Fields()->dataFieldByName($this->sanitiseClassName(SubsiteDomain::class));
+            $grid->setList($grid->getList()->filter('SubsiteID', 0));
         }
 
         return $form;

--- a/src/Admin/SubsiteAdmin.php
+++ b/src/Admin/SubsiteAdmin.php
@@ -40,7 +40,7 @@ class SubsiteAdmin extends ModelAdmin
         $form = parent::getEditForm($id, $fields);
 
         if ($this->modelClass === Subsite::class) {
-            $grid = $form->Fields()->dataFieldByName(str_replace('\\', '-', Subsite::class));
+            $grid = $form->Fields()->dataFieldByName($this->sanitiseClassName(Subsite::class));
             if ($grid) {
                 $grid->getConfig()->getComponentByType(GridFieldPaginator::class)->setItemsPerPage(100);
                 $grid->getConfig()->removeComponentsByType(GridFieldDetailForm::class);

--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -412,9 +412,7 @@ class SiteTreeSubsites extends DataExtension
         // Generate the existing absolute URL and replace the domain with the subsite domain.
         // This helps deal with Link() returning an absolute URL.
         $url = Director::absoluteURL($this->owner->Link($action));
-        if ($this->owner->SubsiteID) {
-            $url = preg_replace('/\/\/[^\/]+\//', '//' . $this->owner->Subsite()->domain() . '/', $url);
-        }
+        $url = preg_replace('/\/\/[^\/]+\//', '//' . $this->owner->Subsite()->domain() . '/', $url);
         return $url;
     }
 

--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -885,6 +885,16 @@ class Subsite extends DataObject
      */
     public function getPrimarySubsiteDomain()
     {
+        // Main site
+        if (!$this->isInDB()) {
+            Subsite::disable_subsite_filter(true);
+            $domain = SubsiteDomain::get()->filter('SubsiteID', 0)
+                ->sort('"IsPrimary" DESC')
+                ->first();
+            Subsite::disable_subsite_filter(false);
+            return $domain;
+        }
+        // Subsites
         return $this
             ->Domains()
             ->sort('"IsPrimary" DESC')


### PR DESCRIPTION
Fixes #472 

This ensures the `AbsoluteLink` for pages will always be correct for main site pages (if a domain is set up for the main site) - even when calling it from the context of a subsite. This allows easily linking to main site pages from subsites, as well as any other situation where the absolute URL for the main site needs to be fetched correctly.