### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "silverstripe/framework": "^4.10",
         "silverstripe/cms": "^4.4@dev",
         "silverstripe/admin": "^1.4@dev",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219
