### PR TITLE
MNT Fix github action for deploying userdocs

### DIFF
--- a/.github/workflows/deploy-userhelp-docs.yml
+++ b/.github/workflows/deploy-userhelp-docs.yml
@@ -1,13 +1,15 @@
-name: Build Docs
+name: Deploy Userhelp Docs
 on:
   push:
     branches:
+      - '3'
+      - '2'
       - '1.1'
     paths:
       - 'docs/en/userguide/**'
 jobs:
-  build:
-    name: build-docs
+  deploy:
+    name: deploy-userhelp-docs
     runs-on: ubuntu-latest
     steps:
       - name: Run build hook


### PR DESCRIPTION
- Set the branches that activate the action to match the ones used by userhelp according to [the userhelp sources json](https://github.com/silverstripe/doc.silverstripe.org/blob/master/sources-user.js)
- More clearly and accurately identify the specific action (main.yml is hardly specific) in case future actions are also added.

## Parent issue
- https://github.com/silverstripe/doc.silverstripe.org/issues/246