### PR TITLE
API Deprecate passing multiple IDs

### DIFF
--- a/src/State/SubsiteState.php
+++ b/src/State/SubsiteState.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Subsites\State;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Resettable;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * SubsiteState provides static access to the current state for subsite related data during a request
@@ -48,6 +49,9 @@ class SubsiteState implements Resettable
      */
     public function setSubsiteId($id)
     {
+        if (!ctype_digit((string) $id) && !is_null($id)) {
+            Deprecation::notice('2.8.0', 'Passing multiple IDs is deprecated, only pass a single ID instead.');
+        }
         if (is_null($this->originalSubsiteId)) {
             $this->originalSubsiteId = (int) $id;
         }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10546

Passing multiple ID's makes for flaky code, it also probably doesn't actually work right now e.g. https://github.com/silverstripe/silverstripe-subsites/blob/2.7/src/Extensions/FileSubsites.php#L95