### PR TITLE
FIX Remove wildcard from config

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,7 +1,6 @@
 ---
 Name: subsiteconfig
-After:
-  - 'framework/*'
+After: 'assetadmin'
 ---
 SilverStripe\AssetAdmin\Controller\AssetAdmin:
   treats_subsite_0_as_global: true

--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -1,7 +1,5 @@
 ---
 Name: subsiteextensions
-After:
-  - 'framework/*'
 ---
 SilverStripe\CMS\Model\SiteTree:
   extensions:


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-subsites/issues/506

Fixes an issue where if you have have a `MAILER_DSN` set in .env, a circular dependency happens on flush=1

`PHP Fatal error:  Uncaught MJS\TopSort\CircularDependencyException: Circular dependency found: modelascontrollercatchallroute->subsiteconfig->mailer-dsn-env->subsiteconfig in /var/www/vendor/marcj/topsort/src/CircularDependencyException.php:34`

This happens in because of the new [mailer config](https://github.com/silverstripe/silverstripe-framework/blob/5/_config/mailer.yml#L21) which uses an `After: '*'`

Unit test failures are unrelated and will be fixed in https://github.com/silverstripe/silverstripe-subsites/pull/503

