### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/cms": "4.13.x-dev",
-        "silverstripe/admin": "1.13.x-dev",
-        "silverstripe/asset-admin": "1.13.x-dev",
-        "silverstripe/errorpage": "1.13.x-dev",
-        "silverstripe/versioned": "1.13.x-dev"
+        "silverstripe/framework": "^4.10",
+        "silverstripe/cms": "^4.4@dev",
+        "silverstripe/admin": "^1.4@dev",
+        "silverstripe/asset-admin": "^1.4@dev",
+        "silverstripe/errorpage": "^1.4@dev",
+        "silverstripe/versioned": "^1.4@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

See https://github.com/silverstripe/silverstripe-subsites/commit/04fe468f36ab82f18df712b2f6edcd884d8f02b1

## Issue
- https://github.com/silverstripe/.github/issues/33