### PR TITLE
Add extension to correctly support element preview

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -64,3 +64,12 @@ SilverStripe\Subsites\Admin\SubsiteAdmin:
 SilverStripe\SiteConfig\SiteConfigLeftAndMain:
   extensions:
     - SilverStripe\Subsites\Extensions\SubsiteMenuExtension
+
+---
+Name: subsite-preview-elemental
+Only:
+  classexists: DNADesign\Elemental\Models\BaseElement
+---
+DNADesign\Elemental\Models\BaseElement:
+  extensions:
+    - SilverStripe\Subsites\Extensions\BaseElementSubsites

--- a/src/Extensions/BaseElementSubsites.php
+++ b/src/Extensions/BaseElementSubsites.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\Subsites\Extensions;
+
+use SilverStripe\Control\HTTP;
+use SilverStripe\ORM\DataExtension;
+
+/**
+ * Extension for the BaseElement object to add subsites support for CMS previews
+ */
+class BaseElementSubsites extends DataExtension
+{
+    /**
+     * Set SubsiteID to avoid errors when a page doesn't exist on the CMS domain.
+     *
+     * @param string &$link
+     * @param string|null $action
+     * @return string
+     */
+    public function updatePreviewLink(&$link)
+    {
+        // Get subsite ID from the element or from its page. Defaults to 0 automatically.
+        $subsiteID = $this->owner->SubsiteID;
+        if (is_null($subsiteID)) {
+            $page = $this->owner->getPage();
+            if ($page) {
+                $subsiteID = $page->SubsiteID;
+            }
+        }
+
+        $link = HTTP::setGetVar('SubsiteID', intval($subsiteID), $link);
+    }
+}


### PR DESCRIPTION
As per the title, conditional based on base element class existing.

Tried to get the subsite ID from the element, if it has the model extension adding it applied, or from its page.

Targeting 2.8 as I see this as a fix for a broken preview mechanism rather than a new feature or an enhancement, but ok to target 3.0 as well since this can easily be done in project code until this is released.