### PR TITLE
don't trigger permissionFailure when it's not needed

### DIFF
--- a/src/Extensions/LeftAndMainSubsites.php
+++ b/src/Extensions/LeftAndMainSubsites.php
@@ -369,7 +369,7 @@ class LeftAndMainSubsites extends LeftAndMainExtension
             }
 
             // We have not found any accessible section or subsite. User should be denied access.
-            return Security::permissionFailure($this->owner);
+            // This is handled already by LeftAndMain thanks to alternateAccessCheck
         }
 
         // Current site is accessible. Allow through.


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-subsites/issues/529

LeftAndMain already has a canView check that will use under the hood the alternateAccessCheck
Not trigger the permissionFailure allows proper handling of the error instead of showing a ever loading logo in admin v5