### PR TITLE
MNT Remove unused Translatable

### DIFF
--- a/src/Extensions/ErrorPageSubsite.php
+++ b/src/Extensions/ErrorPageSubsite.php
@@ -48,17 +48,7 @@ class ErrorPageSubsite extends DataExtension
             $subdomainPart = "-{$subdomain}";
         }
 
-        // @todo implement Translatable namespace
-        if (singleton(SiteTree::class)->hasExtension('Translatable')
-            && $locale
-            && $locale != Translatable::default_locale()
-        ) {
-            $fileName = "error-{$statusCode}-{$locale}{$subdomainPart}.html";
-        } else {
-            $fileName=  "error-{$statusCode}{$subdomainPart}.html";
-        }
-
-        $fileName = FileNameFilter::create()->filter($fileName);
+        $fileName = FileNameFilter::create()->filter("error-{$statusCode}{$subdomainPart}.html");
 
         $name = implode('/', [$static_filepath, $fileName]);
     }


### PR DESCRIPTION
## Description
The Translatable module is no longer in use.
### Related issue
- https://github.com/silverstripe/silverstripe-framework/issues/10548