### PR TITLE
ENH Use cached table list from ClassInfo

### DIFF
--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -256,8 +256,9 @@ class Subsite extends DataObject
             $schema = DataObject::getSchema();
 
             $domainTableName = $schema->tableName(SubsiteDomain::class);
-            
-            if (!DB::get_schema()->hasTable($domainTableName)) {
+
+            // ClassInfo::hasTable provides a cached table list
+            if (!ClassInfo::hasTable($domainTableName)) {
                 // Table hasn't been created yet. Might be a dev/build, skip.
                 return 0;
             }

--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -32,6 +32,7 @@ use SilverStripe\Subsites\Service\ThemeResolver;
 use SilverStripe\Subsites\State\SubsiteState;
 use SilverStripe\Versioned\Versioned;
 use UnexpectedValueException;
+use SilverStripe\Core\ClassInfo;
 
 /**
  * A dynamically created subsite. SiteTree objects can now belong to a subsite.

--- a/src/Model/SubsiteDomain.php
+++ b/src/Model/SubsiteDomain.php
@@ -9,6 +9,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\OptionsetField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Subsites\Forms\WildcardDomainField;
+use SilverStripe\Core\ClassInfo;
 
 /**
  * @property string $Domain domain name of this subsite. Can include wildcards. Do not include the URL scheme here

--- a/src/Model/SubsiteDomain.php
+++ b/src/Model/SubsiteDomain.php
@@ -9,7 +9,6 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\OptionsetField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Subsites\Forms\WildcardDomainField;
-use SilverStripe\Core\ClassInfo;
 
 /**
  * @property string $Domain domain name of this subsite. Can include wildcards. Do not include the URL scheme here


### PR DESCRIPTION
## Description

Fixes https://github.com/silverstripe/silverstripe-subsites/issues/563

Using ClassInfo::hasTable, the cached data is used and avoid extra query per request

## Manual testing steps

Install debugbar
Install subsite module
Check that no extra query is made

## Issues
- https://github.com/silverstripe/silverstripe-subsites/issues/563

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
