### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.12",
         "silverstripe/cms": "^4.4@dev",
         "silverstripe/admin": "^1.4@dev",
         "silverstripe/asset-admin": "^1.4@dev",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Fixes a deprecation warning causing a fatal error on --prefer-lowest build
1) SilverStripe\Subsites\Tests\SubsiteAdminFunctionalTest::testAdminIsRedirectedToObjectsSubsite
SilverStripe\Subsites\Extensions\SiteTreeSubsites->alternatePreviewLink is deprecated. Use updatePreviewLink() instead. Called from call_user_func_array.

https://github.com/silverstripe/silverstripe-subsites/actions/runs/9851672912/job/27198976353