### PR TITLE
FIX Update CMS fields now that they're being scaffolded

### DIFF
--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -53,6 +53,15 @@ class SiteTreeSubsites extends DataExtension
         'CrossSubsiteLinkTracking' => ['FieldName' => 'Varchar']
     ];
 
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            'Subsite',
+        ],
+        'ignoreRelations' => [
+            'CrossSubsiteLinkTracking',
+        ],
+    ];
+
     public function isMainSite()
     {
         return $this->owner->SubsiteID == 0;

--- a/src/Pages/SubsitesVirtualPage.php
+++ b/src/Pages/SubsitesVirtualPage.php
@@ -8,10 +8,8 @@ use SilverStripe\CMS\Model\VirtualPage;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\LiteralField;
-use SilverStripe\Forms\TextareaField;
-use SilverStripe\Forms\TextField;
-use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Subsites\Forms\SubsitesTreeDropdownField;
@@ -21,17 +19,9 @@ use SilverStripe\View\ArrayData;
 
 class SubsitesVirtualPage extends VirtualPage
 {
-
     private static $table_name = 'SubsitesVirtualPage';
 
     private static $description = 'Displays the content of a page on another subsite';
-
-    private static $db = [
-        'CustomMetaTitle' => 'Varchar(255)',
-        'CustomMetaKeywords' => 'Varchar(255)',
-        'CustomMetaDescription' => 'Text',
-        'CustomExtraMeta' => 'HTMLText'
-    ];
 
     private static $non_virtual_fields = [
         'SubsiteID'
@@ -39,121 +29,58 @@ class SubsitesVirtualPage extends VirtualPage
 
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $subsites = DataObject::get(Subsite::class);
+            if (!$subsites) {
+                $subsites = ArrayList::create();
+            } else {
+                $subsites = ArrayList::create($subsites->toArray());
+            }
+            $subsites->push(ArrayData::create(['Title' => 'Main site', 'ID' => 0]));
 
-        $subsites = DataObject::get(Subsite::class);
-        if (!$subsites) {
-            $subsites = new ArrayList();
-        } else {
-            $subsites = ArrayList::create($subsites->toArray());
-        }
-
-        $subsites->push(new ArrayData(['Title' => 'Main site', 'ID' => 0]));
-
-        $fields->addFieldToTab(
-            'Root.Main',
-            DropdownField::create(
-                'CopyContentFromID_SubsiteID',
-                _t(__CLASS__ . '.SubsiteField', 'Subsite'),
-                $subsites->map('ID', 'Title')
-            )->addExtraClass('subsitestreedropdownfield-chooser no-change-track'),
-            'CopyContentFromID'
-        );
-
-        // Setup the linking to the original page.
-        $pageSelectionField = SubsitesTreeDropdownField::create(
-            'CopyContentFromID',
-            _t('SilverStripe\\CMS\\Model\\VirtualPage.CHOOSE', 'Linked Page'),
-            SiteTree::class,
-            'ID',
-            'MenuTitle'
-        );
-
-        $fields->addFieldToTab(
-            'Root.Main',
-            TreeDropdownField::create('CopyContentFromID', 'Linked Page', SiteTree::class)
-        );
-
-        if (Controller::has_curr() && Controller::curr()->getRequest()) {
-            $subsiteID = (int) Controller::curr()->getRequest()->requestVar('CopyContentFromID_SubsiteID');
-            $pageSelectionField->setSubsiteID($subsiteID);
-        }
-        $fields->replaceField('CopyContentFromID', $pageSelectionField);
-
-        // Create links back to the original object in the CMS
-        if ($this->CopyContentFromID) {
-            $editLink = Controller::join_links(
-                CMSPageEditController::singleton()->Link('show'),
-                $this->CopyContentFromID
-            );
-
-            $linkToContent = "
-				<a class=\"cmsEditlink\" href=\"$editLink\">" .
-                _t('SilverStripe\\CMS\\Model\\VirtualPage.EDITCONTENT', 'Click here to edit the content') .
-                '</a>';
-            $fields->removeByName('VirtualPageContentLinkLabel');
             $fields->addFieldToTab(
                 'Root.Main',
-                $linkToContentLabelField = LiteralField::create('VirtualPageContentLinkLabel', $linkToContent),
-                'Title'
+                DropdownField::create(
+                    'CopyContentFromID_SubsiteID',
+                    _t(__CLASS__ . '.SubsiteField', 'Subsite'),
+                    $subsites->map('ID', 'Title')
+                )->addExtraClass('subsitestreedropdownfield-chooser no-change-track'),
+                'CopyContentFromID'
             );
-        }
 
+            // Setup the linking to the original page.
+            $pageSelectionField = SubsitesTreeDropdownField::create(
+                'CopyContentFromID',
+                _t('SilverStripe\\CMS\\Model\\VirtualPage.CHOOSE', 'Linked Page'),
+                SiteTree::class,
+                'ID',
+                'MenuTitle'
+            );
+            if (Controller::has_curr() && Controller::curr()->getRequest()) {
+                $subsiteID = (int) Controller::curr()->getRequest()->requestVar('CopyContentFromID_SubsiteID');
+                $pageSelectionField->setSubsiteID($subsiteID);
+            }
+            $fields->replaceField('CopyContentFromID', $pageSelectionField);
 
-        $fields->addFieldToTab(
-            'Root.Main',
-            TextField::create(
-                'CustomMetaTitle',
-                $this->fieldLabel('CustomMetaTitle')
-            )->setDescription(_t(__CLASS__ . '.OverrideNote', 'Overrides inherited value from the source')),
-            'MetaTitle'
-        );
-        $fields->addFieldToTab(
-            'Root.Main',
-            TextareaField::create(
-                'CustomMetaKeywords',
-                $this->fieldLabel('CustomMetaKeywords')
-            )->setDescription(_t(__CLASS__ . '.OverrideNote', 'Overrides inherited value from the source')),
-            'MetaKeywords'
-        );
-        $fields->addFieldToTab(
-            'Root.Main',
-            TextareaField::create(
-                'CustomMetaDescription',
-                $this->fieldLabel('CustomMetaDescription')
-            )->setDescription(_t(__CLASS__ . '.OverrideNote', 'Overrides inherited value from the source')),
-            'MetaDescription'
-        );
-        $fields->addFieldToTab(
-            'Root.Main',
-            TextField::create(
-                'CustomExtraMeta',
-                $this->fieldLabel('CustomExtraMeta')
-            )->setDescription(_t(__CLASS__ . '.OverrideNote', 'Overrides inherited value from the source')),
-            'ExtraMeta'
-        );
+            // Create links back to the original object in the CMS
+            if ($this->CopyContentFromID) {
+                $editLink = Controller::join_links(
+                    CMSPageEditController::singleton()->Link('show'),
+                    $this->CopyContentFromID
+                );
 
-        return $fields;
-    }
-
-    public function fieldLabels($includerelations = true)
-    {
-        $labels = parent::fieldLabels($includerelations);
-        $labels['CustomMetaTitle'] = _t('SilverStripe\\Subsites\\Model\\Subsite.CustomMetaTitle', 'Title');
-        $labels['CustomMetaKeywords'] = _t(
-            'SilverStripe\\Subsites\\Model\\Subsite.CustomMetaKeywords',
-            'Keywords'
-        );
-        $labels['CustomMetaDescription'] = _t(
-            'SilverStripe\\Subsites\\Model\\Subsite.CustomMetaDescription',
-            'Description'
-        );
-        $labels['CustomExtraMeta'] = _t(
-            'SilverStripe\\Subsites\\Model\\Subsite.CustomExtraMeta',
-            'Custom Meta Tags'
-        );
-
-        return $labels;
+                $linkToContent = "
+                    <a class=\"cmsEditlink\" href=\"$editLink\">" .
+                    _t('SilverStripe\\CMS\\Model\\VirtualPage.EDITCONTENT', 'Click here to edit the content') .
+                    '</a>';
+                $fields->addFieldToTab(
+                    'Root.Main',
+                    LiteralField::create('VirtualPageContentLinkLabel', $linkToContent),
+                    'Title'
+                );
+            }
+        });
+        return parent::getCMSFields();
     }
 
     public function getCopyContentFromID_SubsiteID()
@@ -172,13 +99,6 @@ class SubsitesVirtualPage extends VirtualPage
                 unset($fields[$k]);
             }
         }
-
-        foreach (SubsitesVirtualPage::$db as $field => $type) {
-            if (in_array($field, $fields ?? [])) {
-                unset($fields[array_search($field, $fields)]);
-            }
-        }
-
         return $fields;
     }
 


### PR DESCRIPTION
Relies on changes to `SiteTree` and `VirtualPage` in https://github.com/silverstripe/silverstripe-cms/pull/2983

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2767