### PR TITLE
FIX Correct trailing slash for subsite in another domain

### DIFF
--- a/src/Model/SubsiteDomain.php
+++ b/src/Model/SubsiteDomain.php
@@ -217,9 +217,11 @@ class SubsiteDomain extends DataObject
      */
     public function absoluteBaseURL()
     {
-        return Controller::join_links(
+        $slash = Controller::config()->get('add_trailing_slash') ? '/' : '';
+        $baseURL = Controller::join_links(
             $this->getAbsoluteLink(),
             Director::baseURL()
         );
+        return (rtrim($baseURL, '/')) . $slash;
     }
 }

--- a/tests/php/SubsiteTest.php
+++ b/tests/php/SubsiteTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Subsites\Tests;
 
 use Page;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\DataObject;
@@ -304,7 +305,7 @@ class SubsiteTest extends BaseSubsiteTest
 
         // If there is a Director::baseURL() value this will also be included
         $this->assertEquals(
-            'http://' . $_SERVER['HTTP_HOST'],
+            $this->normaliseTrailingSlash('http://' . $_SERVER['HTTP_HOST']),
             singleton(Subsite::class)->absoluteBaseURL()
         );
     }
@@ -324,7 +325,7 @@ class SubsiteTest extends BaseSubsiteTest
         $model = $this->objFromFixture($class, $identifier);
         $protocol = $currentIsSecure ? 'https' : 'http';
         Config::modify()->set(Director::class, 'alternate_base_url', $protocol . '://www.mysite.com');
-        $this->assertSame($expected, $model->absoluteBaseURL());
+        $this->assertSame($this->normaliseTrailingSlash($expected), $model->absoluteBaseURL());
     }
 
     public function domainProtocolProvider()
@@ -501,5 +502,18 @@ class SubsiteTest extends BaseSubsiteTest
 
         $pages = SiteTree::get();
         $this->assertGreaterThanOrEqual(1, $pages->count());
+    }
+
+    /**
+     * Normalises a test URL's trailing slash, but ignores complexities
+     * such as whether the domain host in the UR matches Director::host()
+     */
+    private function normaliseTrailingSlash(string $testURL): string
+    {
+        if ($testURL === '/' || $testURL === '') {
+            return '/';
+        }
+        $slash = Controller::config()->get('add_trailing_slash') ? '/' : '';
+        return (rtrim($testURL, '/')) . $slash;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-subsites/actions/runs/10278313787/job/28441800184 which consists of failures like the below:

> ```text
> Failed asserting that two strings are identical.
> --- Expected
> +++ Actual
> @@ @@
> -'http://two.mysite.com/'
> +'http://two.mysite.com/'
> ```

As of silverstripe/framework 5.2.20, `Controller::normaliseTrailingSlash()` won't normalise trailing slash for absolute URLs where the domain doesn't match the current site domain.

This means if getting a link to a page on Subsite A from Subsite B, if the domains don't match, the trailing slash won't be normalised.

It's possible that it would be better to implement the `updateIsSiteUrl()` extension hook in an extension for `Director` and saying "yes that's a site URL" if it belongs to a domain of any subsite. I didn't attempt that because I don't know what sort of flow-on effects that might have. I'm especially hesitant to do that in a patch release.

Note that the same problem happened on Fluent, see https://github.com/tractorcow-farm/silverstripe-fluent/pull/872
Most likely we'll want to implement the `updateIsSiteUrl()` extension hook for both modules in a minor release, but I want at least one other opinion before I do that. Either way, IMO this PR should be merged for a patch fix.

## Issue
- https://github.com/silverstripe/.github/issues/290