### PR TITLE
ENH Don't use deprecated method

### DIFF
--- a/src/Tasks/SubsiteCopyPagesTask.php
+++ b/src/Tasks/SubsiteCopyPagesTask.php
@@ -78,7 +78,7 @@ class SubsiteCopyPagesTask extends BuildTask
                     $childClone->copyVersionToStage('Stage', 'Live');
                     array_push($stack, [$child->ID, $childClone->ID]);
 
-                    Deprecation::withNoReplacement(function () use ($child) {
+                    Deprecation::withSuppressedNotice(function () use ($child) {
                         $this->log(sprintf('Copied "%s" (#%d, %s)', $child->Title, $child->ID, $child->Link()));
                     });
                 }


### PR DESCRIPTION
Relies on https://github.com/silverstripe/silverstripe-framework/pull/11390

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11382