### PR TITLE
API Ensure themelist returns an array

### DIFF
--- a/src/Extensions/LeftAndMainSubsites.php
+++ b/src/Extensions/LeftAndMainSubsites.php
@@ -17,7 +17,7 @@ use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\SS_List;
+use SilverStripe\Model\List\SS_List;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;

--- a/src/Service/ThemeResolver.php
+++ b/src/Service/ThemeResolver.php
@@ -41,7 +41,7 @@ class ThemeResolver
      * @param Subsite $site
      * @return array
      */
-    public function getThemeList(Subsite $site)
+    public function getThemeList(Subsite $site): array
     {
         $themes = array_values(SSViewer::get_themes() ?? []);
         $siteTheme = $site->Theme;


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/328

Fixes https://github.com/silverstripe/silverstripe-subsites/actions/runs/11697085928/job/32899670628

`1) SilverStripe\Subsites\Tests\SiteTreeSubsitesTest::testThemeResolverIsUsedForSettingThemeList
TypeError: SilverStripe\View\SSViewer::set_themes(): Argument #1 ($themes) must be of type array, null given, called in /home/runner/work/silverstripe-subsites/silverstripe-subsites/src/Extensions/SiteTreeSubsites.php on line 405`