### PR TITLE
MNT Fix unit test

### DIFF
--- a/src/Extensions/GroupSubsites.php
+++ b/src/Extensions/GroupSubsites.php
@@ -126,6 +126,17 @@ class GroupSubsites extends Extension implements PermissionProvider
         }
     }
 
+    public function getTreeTitle(): string
+    {
+        // Overrides Hierachy::getTreeTitle() to change where Convert::raw2xml() is called
+        // so that the html added updateTreeTitle() is not escaped.
+        $owner = $this->getOwner();
+        $title = $owner->MenuTitle ?: $owner->Title;
+        $title = Convert::raw2xml($title);
+        $owner->extend('updateTreeTitle', $title);
+        return $title;
+    }
+
     /**
      * If this group belongs to a subsite, append the subsites title to the group title to make it easy to
      * distinguish in the tree-view of the security admin interface.


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Fixes https://github.com/silverstripe/silverstripe-subsites/actions/runs/12342588552/job/34442723479#step:12:109

```
1) SilverStripe\Subsites\Tests\GroupSubsitesTest::testAlternateTreeTitle
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'The A Team <i>(global group)</i>'
+'The A Team &lt;i&gt;(global group)&lt;/i&gt;'
```