### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/cms": "^6",
         "silverstripe/admin": "^3",
         "silverstripe/asset-admin": "^3",

--- a/src/Extensions/ErrorPageSubsite.php
+++ b/src/Extensions/ErrorPageSubsite.php
@@ -41,7 +41,7 @@ class ErrorPageSubsite extends Extension
         if (!$subsite) {
             $subsiteID = Subsite::getSubsiteIDForDomain();
             if ($subsiteID != 0) {
-                $subsite = DataObject::get_by_id(Subsite::class, $subsiteID);
+                $subsite = Subsite::get()->setUseCache(true)->byID($subsiteID);
             } else {
                 $subsite = null;
             }

--- a/src/Extensions/LeftAndMainSubsites.php
+++ b/src/Extensions/LeftAndMainSubsites.php
@@ -118,7 +118,7 @@ class LeftAndMainSubsites extends Extension implements TemplateGlobalProvider
             return ArrayList::create();
         }
         if (!is_object($member)) {
-            $member = DataObject::get_by_id(Member::class, $member);
+            $member = Member::get()->setUseCache(true)->byID($member);
         }
 
         // Collect permissions - honour the LeftAndMain::required_permission_codes, current model requires
@@ -397,8 +397,8 @@ class LeftAndMainSubsites extends Extension implements TemplateGlobalProvider
      */
     public function copytosubsite($data, $form)
     {
-        $page = DataObject::get_by_id(SiteTree::class, $data['ID']);
-        $subsite = DataObject::get_by_id(Subsite::class, $data['CopyToSubsiteID']);
+        $page = SiteTree::get()->setUseCache(true)->byID($data['ID']);
+        $subsite = Subsite::get()->setUseCache(true)->byID($data['CopyToSubsiteID']);
         $includeChildren = (isset($data['CopyToSubsiteWithChildren'])) ? $data['CopyToSubsiteWithChildren'] : false;
 
         $newPage = $page->duplicateToSubsite($subsite->ID, $includeChildren);

--- a/src/Extensions/SiteTreeSubsites.php
+++ b/src/Extensions/SiteTreeSubsites.php
@@ -52,7 +52,7 @@ class SiteTreeSubsites extends Extension
     private static $many_many_extraFields = [
         'CrossSubsiteLinkTracking' => ['FieldName' => 'Varchar']
     ];
-    
+
     /**
     * Used to cache the result of a heavily called database query
     */
@@ -307,7 +307,7 @@ class SiteTreeSubsites extends Extension
         if (!$this->owner->SubsiteID) {
             return false;
         }
-        $sc = DataObject::get_one(SiteConfig::class, '"SubsiteID" = ' . $this->owner->SubsiteID);
+        $sc = SiteConfig::get()->setUseCache(true)->find('SubsiteID', $this->owner->SubsiteID);
         if (!$sc) {
             $sc = new SiteConfig();
             $sc->SubsiteID = $this->owner->SubsiteID;

--- a/src/Model/Subsite.php
+++ b/src/Model/Subsite.php
@@ -391,7 +391,7 @@ class Subsite extends DataObject
             return ArrayList::create();
         }
         if (!is_object($member)) {
-            $member = DataObject::get_by_id(Member::class, $member);
+            $member = Member::get()->setUseCache(true)->byID($member);
         }
 
         $subsites = ArrayList::create();
@@ -441,7 +441,7 @@ class Subsite extends DataObject
             return new ArrayList();
         }
         if (!is_object($member)) {
-            $member = DataObject::get_by_id(Member::class, $member);
+            $member = Member::get()->setUseCache(true)->byID($member);
         }
 
         // Rationalise permCode argument

--- a/src/Pages/SubsitesVirtualPage.php
+++ b/src/Pages/SubsitesVirtualPage.php
@@ -108,7 +108,7 @@ class SubsitesVirtualPage extends VirtualPage
         $oldState = Subsite::$disable_subsite_filter;
         Subsite::$disable_subsite_filter = true;
         if ($this->CopyContentFromID) {
-            $this->HasBrokenLink = DataObject::get_by_id(SiteTree::class, $this->CopyContentFromID) ? false : true;
+            $this->HasBrokenLink = SiteTree::get()->setUseCache(true)->byID($this->CopyContentFromID) ? false : true;
         }
         Subsite::$disable_subsite_filter = $oldState;
     }

--- a/src/Tasks/SubsiteCopyPagesTask.php
+++ b/src/Tasks/SubsiteCopyPagesTask.php
@@ -39,7 +39,7 @@ class SubsiteCopyPagesTask extends BuildTask
             $output->writeln('<error>Missing "from" parameter</>');
             return Command::INVALID;
         }
-        $subsiteFrom = DataObject::get_by_id(Subsite::class, $subsiteFromId);
+        $subsiteFrom = Subsite::get()->setUseCache(true)->byID($subsiteFromId);
         if (!$subsiteFrom) {
             $output->writeln('<error>Subsite not found</>');
             return Command::FAILURE;
@@ -50,7 +50,7 @@ class SubsiteCopyPagesTask extends BuildTask
             $output->writeln('<error>Missing "to" parameter</>');
             return Command::INVALID;
         }
-        $subsiteTo = DataObject::get_by_id(Subsite::class, $subsiteToId);
+        $subsiteTo = Subsite::get()->setUseCache(true)->byID($subsiteToId);
         if (!$subsiteTo) {
             $output->writeln('<error>Subsite not found</>');
             return Command::FAILURE;

--- a/tests/php/SubsiteTest.php
+++ b/tests/php/SubsiteTest.php
@@ -58,13 +58,10 @@ class SubsiteTest extends BaseSubsiteTest
         // Test that changeSubsite is working
         Subsite::changeSubsite($template->ID);
         $this->assertEquals($template->ID, SubsiteState::singleton()->getSubsiteId());
-        $tmplStaff = $this->objFromFixture('Page', 'staff');
-        $tmplHome = DataObject::get_one('Page', "\"URLSegment\" = 'home'");
 
         // Publish all the pages in the template, testing that DataObject::get only returns pages
         // from the chosen subsite
         $pages = DataObject::get(SiteTree::class);
-        $totalPages = $pages->count();
         foreach ($pages as $page) {
             $this->assertEquals($template->ID, $page->SubsiteID);
             $page->copyVersionToStage('Stage', 'Live');
@@ -79,7 +76,7 @@ class SubsiteTest extends BaseSubsiteTest
         // Another test that changeSubsite is working
         $subsite->activate();
 
-        $siteHome = DataObject::get_one('Page', "\"URLSegment\" = 'home'");
+        $siteHome = Page::get()->find('URLSegment', 'home');
         $this->assertNotEquals($siteHome, false, 'Home Page for subsite not found');
         $this->assertEquals(
             $subsite->ID,
@@ -482,16 +479,16 @@ class SubsiteTest extends BaseSubsiteTest
         $subsite2 = $subsite1->duplicate();
         $subsite2->activate();
         // change content on dupe
-        $page2 = DataObject::get_one('Page', "\"Title\" = 'MyAwesomePage'");
+        $page2 = Page::get()->find('Title', 'MyAwesomePage');
         $page2->Title = 'MyNewAwesomePage';
         $page2->write();
         $page2->publishRecursive();
 
         // check change & check change has not affected subiste1
         $subsite1->activate();
-        $this->assertEquals('MyAwesomePage', DataObject::get_by_id('Page', $page1->ID)->Title);
+        $this->assertEquals('MyAwesomePage', Page::get()->byID($page1->ID)->Title);
         $subsite2->activate();
-        $this->assertEquals('MyNewAwesomePage', DataObject::get_by_id('Page', $page2->ID)->Title);
+        $this->assertEquals('MyNewAwesomePage', Page::get()->byID($page2->ID)->Title);
     }
 
     public function testDefaultPageCreatedWhenCreatingSubsite()


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

Tests have been updated to remove caching where it's not relevant to the test.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
