### PR TITLE
Return ArrayList instead of false in LeftAndMainSubsites::SubsiteSwitchList()

### DIFF
--- a/src/Extensions/LeftAndMainSubsites.php
+++ b/src/Extensions/LeftAndMainSubsites.php
@@ -72,7 +72,7 @@ class LeftAndMainSubsites extends LeftAndMainExtension implements TemplateGlobal
         $currentSubsiteID = SubsiteState::singleton()->getSubsiteId();
 
         if ($list == null || $list->count() == 1 && $list->first()->DefaultSite == true) {
-            return false;
+            return ArrayList::create();
         }
 
         Requirements::javascript('silverstripe/subsites:client/dist/js/LeftAndMain_Subsites.js');


### PR DESCRIPTION
## Description
When a member, whose access is limited by subsite, logs in, they get the error below:

"Uncaught TypeError: SilverStripe\Subsites\Extensions\LeftAndMainSubsites::SubsiteSwitchList(): Return value must be of type SilverStripe\ORM\SS_List, false returned."

This PR just changes the return value from false to an ArrayList to comply with the more restrictive function updates.

## Manual testing steps
- create a Group, whose parent group is 'Administrators'
- in the 'Subsites' tab, limit it to one subsite
- log in using an account that belong to this group
- error displays on login

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
