### PR TITLE
Auto-switch to only accessible subsite on CMS init, fixes #508.

### DIFF
--- a/src/Extensions/LeftAndMainSubsites.php
+++ b/src/Extensions/LeftAndMainSubsites.php
@@ -56,15 +56,15 @@ class LeftAndMainSubsites extends Extension implements TemplateGlobalProvider
     /**
      * Generates a list of subsites with the data needed to
      * produce a dropdown site switcher
-     * @return SS_List<Subsite>
+     * @return SS_List<Subsite>|null
      */
-    public static function SubsiteSwitchList(): SS_List
+    public static function SubsiteSwitchList(): SS_List|null
     {
         $list = Subsite::all_accessible_sites();
         $currentSubsiteID = SubsiteState::singleton()->getSubsiteId();
 
-        if ($list == null || $list->count() == 1 && $list->first()->DefaultSite == true) {
-            return false;
+        if (!$list || $list->count() <= 1) {
+            return null;
         }
 
         $output = ArrayList::create();
@@ -337,7 +337,21 @@ class LeftAndMainSubsites extends Extension implements TemplateGlobalProvider
             return $this->owner->redirect(AdminRootController::config()->get('url_base') . '/');
         }
 
-        // SECOND, check if we need to change subsites due to lack of permissions.
+        // SECOND, if the user only has access to one subsite, auto-switch to it.
+
+        $member = Security::getCurrentUser();
+        if ($member && !Permission::checkMember($member, ['ADMIN', 'CMS_ACCESS_LeftAndMain'])) {
+            $accessibleSites = $this->owner->sectionSites(true, 'Main site', $member);
+            if ($accessibleSites->count() === 1) {
+                $onlySite = $accessibleSites->first();
+                if ((int) $onlySite->ID !== (int) $state->getSubsiteId()) {
+                    Subsite::changeSubsite($onlySite->ID);
+                    return $this->owner->redirect(AdminRootController::config()->get('url_base') . '/');
+                }
+            }
+        }
+
+        // THIRD, check if we need to change subsites due to lack of permissions.
 
         if (!$this->canAccess()) {
             $member = Security::getCurrentUser();

--- a/tests/php/LeftAndMainSubsitesTest.php
+++ b/tests/php/LeftAndMainSubsitesTest.php
@@ -12,6 +12,7 @@ use SilverStripe\Security\Member;
 use SilverStripe\Subsites\Extensions\LeftAndMainSubsites;
 use SilverStripe\Subsites\Model\Subsite;
 use SilverStripe\Subsites\State\SubsiteState;
+use SilverStripe\Control\Director;
 
 class LeftAndMainSubsitesTest extends FunctionalTest
 {
@@ -110,5 +111,57 @@ class LeftAndMainSubsitesTest extends FunctionalTest
         /** @var LeftAndMain&LeftAndMainSubsites $leftAndMain */
         $leftAndMain = new LeftAndMain();
         $this->assertTrue($leftAndMain->alternateAccessCheck($member));
+    }
+
+    public function testSubsiteSwitchListNullForSingleAccessUser()
+    {
+        $this->logInAs('subsite1member');
+        SubsiteState::singleton()->setUseSessions(true);
+
+        $result = LeftAndMainSubsites::SubsiteSwitchList();
+        $this->assertNull($result, 'SubsiteSwitchList should return null when user has access to only one subsite');
+    }
+
+    public function testAutoSwitchToOnlyAccessibleSubsite()
+    {
+        SubsiteState::singleton()->setUseSessions(true);
+        $this->logInAs('subsite1member');
+
+        $subsite1 = $this->objFromFixture(Subsite::class, 'subsite1');
+
+        // Start on the main site (ID 0)
+        Subsite::changeSubsite(0);
+        $this->session()->set('SubsiteID', 0);
+
+        $response = $this->get('admin/');
+
+        // Should have been redirected (not a login redirect)
+        $this->assertGreaterThanOrEqual(300, $response->getStatusCode());
+        $this->assertLessThan(400, $response->getStatusCode());
+
+        // InitStateMiddleware writes SubsiteID to session in its finally block
+        $this->assertEquals(
+            $subsite1->ID,
+            (int) $this->session()->get('SubsiteID'),
+            'User with access to one subsite should be auto-switched to it'
+        );
+    }
+
+    public function testAdminNotAutoSwitched()
+    {
+        SubsiteState::singleton()->setUseSessions(true);
+        $this->logInAs('admin');
+
+        // Start on the main site (ID 0)
+        Subsite::changeSubsite(0);
+        $this->session()->set('SubsiteID', 0);
+
+        $this->get('admin/');
+
+        $this->assertEquals(
+            0,
+            (int) $this->session()->get('SubsiteID'),
+            'Admin user should not be auto-switched away from the main site'
+        );
     }
 }


### PR DESCRIPTION
## Description
To fix #508 , we redirect the user on the accessible website on load.

## Manual testing steps
Follow the steps in the ussues

## Issues
- #508 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
